### PR TITLE
Add overloads to component SetState

### DIFF
--- a/Bridge.React/Components/Component.cs
+++ b/Bridge.React/Components/Component.cs
@@ -188,5 +188,15 @@ namespace Bridge.React
 		{
 			Script.Write("this.setState({ value: state })");
 		}
+		
+		/// <summary>
+		/// This replaces the entire state for the component instance, and executes the callback delegate when the state has been
+		/// successfully mutated. See http://stackoverflow.com/questions/30782948/why-calling-react-setstate-method-doesnt-mutate-the-state-immediately
+		/// </summary>
+		[Name("setWrappedStateCallback")]
+		protected void SetState(TState state, Action action)
+		{
+			Script.Write("this.setState({ value: state }, action)");
+		}
 	}
 }

--- a/Bridge.React/Components/Component.cs
+++ b/Bridge.React/Components/Component.cs
@@ -198,5 +198,16 @@ namespace Bridge.React
 		{
 			Script.Write("this.setState({ value: state }, action)");
 		}
+		
+		/// <summary>
+		/// This replaces the entire state for the component instance asynchronously. Execution will continue when the state has been successfully mutated.
+		/// </summary>
+		[Name("setWrappedStateAsync")]
+		protected Task SetStateAsync(TState state)
+		{
+			TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
+			SetState(state, () => tcs.SetResult(null));
+			return tcs.Task;
+		}
 	}
 }


### PR DESCRIPTION
According to [the react documentation](https://facebook.github.io/react/docs/component-api.html):

> setState() does not immediately mutate this.state but creates a pending state transition. Accessing this.state after calling this method can potentially return the existing value.

If needing to access the state object after calling `SetState`, you should use the overload of `SetState` which has callback support. I've also added an async version in the spirit of C#. 

Also See:
http://stackoverflow.com/questions/30782948/why-calling-react-setstate-method-doesnt-mutate-the-state-immediately