### PR TITLE
Added inline styling support, updated TodoApp

### DIFF
--- a/Bridge.React.Examples/Bridge.React.Examples.csproj
+++ b/Bridge.React.Examples/Bridge.React.Examples.csproj
@@ -45,6 +45,7 @@
     <Compile Include="App.cs" />
     <Compile Include="TodoApp.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TodoStyles.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Bridge\bridge.json" />

--- a/Bridge.React.Examples/Bridge/www/demo.html
+++ b/Bridge.React.Examples/Bridge/www/demo.html
@@ -13,7 +13,7 @@
 
 <body>
     <style>
-        .done {
+        /*.done {
             color: #808080;
             text-decoration: line-through;
         }
@@ -62,7 +62,7 @@
            margin:10px;
            min-height:40px;
            min-width:40px;
-       }
+       }*/
 
     </style>
     <div id="main"></div>

--- a/Bridge.React.Examples/TodoApp.cs
+++ b/Bridge.React.Examples/TodoApp.cs
@@ -22,7 +22,7 @@ namespace Bridge.React.Examples
 			};
 		}
 
-		private State AppendTodo(string todoDescription)
+		private void AppendTodo(string todoDescription)
 		{
 			var count = state.Todos.Count();
 			var todo = new Todo
@@ -32,23 +32,23 @@ namespace Bridge.React.Examples
 				Id = _nextAvailableId++
 			};
 
-			return new State
+			SetState(new State
 			{
 				InputValue = "",
 				Todos = state.Todos.Append(todo)
-			};
+			});
 		}
 
-		private State RemoveTodo(int id)
+		private void RemoveTodo(int id)
 		{
-			return new State
+			SetState(new State
 			{
 				InputValue = state.InputValue,
 				Todos = state.Todos.Where(todo => todo.Id != id)
-			};
+			});
 		}
 
-		private State ToggleDone(int id)
+		private void ToggleDone(int id)
 		{
 			var todos = state.Todos.ToArray();
 			for(int i = 0; i < todos.Length; i++)
@@ -59,16 +59,19 @@ namespace Bridge.React.Examples
 				}
 			}
 
-			return new State
+			SetState(new State
 			{
 				InputValue = state.InputValue,
 				Todos = todos
-			};
+			});
 		}
 
 		public override ReactElement Render()
 		{
-			return DOM.Div(new Attributes { ClassName = "wrapper" },
+			return DOM.Div(new Attributes
+            {
+                Style = Style.Margin(5).Padding(5).FontSize(18)
+            },
 				DOM.H3(props.Label),
 				DOM.Label("Description"),
 				DOM.Input(new InputAttributes
@@ -80,27 +83,29 @@ namespace Bridge.React.Examples
 					new ButtonAttributes
 					{
 						Disabled = string.IsNullOrWhiteSpace(state.InputValue),
-						OnClick = e => SetState(AppendTodo(state.InputValue))
+						OnClick = e => AppendTodo(state.InputValue)
 					},
 					"Add"
 				),
 				DOM.Div(
 					state.Todos.Select(todo =>
-						DOM.Div(new Attributes { Key = todo.Id, ClassName = "todo-container" },
-							DOM.H4(new Attributes { ClassName = todo.Done ? "done" : "not-done" }, todo.Description),
+						DOM.Div(new Attributes { Key = todo.Id, Style = TodoStyles.Container },
+							DOM.H4(
+                                new Attributes { Style = todo.Done ? TodoStyles.TextDone : TodoStyles.TextNotDone },
+                                todo.Description),
 							DOM.Button(
 								new ButtonAttributes
 								{
-									ClassName = todo.Done ? "toggle-done" : "toggle-not-done",
-									OnClick = e => SetState(ToggleDone(todo.Id))
+                                    Style = todo.Done ? TodoStyles.ToggleButtonDone : TodoStyles.ToggleButtonNotDone,
+									OnClick = e => ToggleDone(todo.Id)
 								},
 								todo.Done ? "Not done yet!" : "Finished!"
 							),
 							DOM.Button(
 								new ButtonAttributes
 								{
-									ClassName = "remove-btn",
-									OnClick = e => SetState(RemoveTodo(todo.Id))
+									Style = TodoStyles.RemoveButton,
+									OnClick = e => RemoveTodo(todo.Id)
 								},
 								"Remove"
 							)

--- a/Bridge.React.Examples/TodoStyles.cs
+++ b/Bridge.React.Examples/TodoStyles.cs
@@ -1,0 +1,62 @@
+﻿using Bridge.Html5;
+
+namespace Bridge.React.Examples
+{
+    public static class TodoStyles
+    {
+        public static readonly ReactStyle Container = new ReactStyle
+        {
+            Border = "2px solid rgba(129, 115, 105, 0.46)",
+            BorderRadius = 15,
+            Padding = 10,
+            Margin = 20,
+            MaxWidth = 400,
+            Float = Float.Left
+        };
+
+        public static readonly ReactStyle TextDone = new ReactStyle
+        {
+            Color = "#808080",
+            TextDecoration = TextDecoration.LineThrough
+        };
+
+        public static readonly ReactStyle TextNotDone = new ReactStyle
+        {
+            Color = "#50a144",
+        };
+
+
+        private static readonly ReactStyle ButtonBase = new ReactStyle
+        {
+            FontWeight = "900",
+            Margin = 10,
+            MinHeight = 40,
+            MinWidth = 40
+        };
+
+        public static readonly ReactStyle RemoveButton = ButtonBase.MergeWith(new ReactStyle
+        {
+            BackgroundColor = "#e03242",
+            Color = "white",
+            Border = "1px solid white",
+            BorderRadius = 5
+        });
+
+
+        public static ReactStyle ToggleButtonDone = ButtonBase.MergeWith(new ReactStyle
+        {
+            BackgroundColor = "#808080",
+            Color = "white",
+            Border = "1px solid white",
+            BorderRadius = 5
+        });
+
+        public static ReactStyle ToggleButtonNotDone = ButtonBase.MergeWith(new ReactStyle
+        {
+            BackgroundColor = "#50a144",
+            Color = "white",
+            Border = "1px solid white",
+            BorderRadius = 5
+        });
+    }
+}

--- a/Bridge.React/Bridge.React.csproj
+++ b/Bridge.React/Bridge.React.csproj
@@ -115,6 +115,8 @@
     <Compile Include="Components\StatelessComponent.cs" />
     <Compile Include="Components\Component.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Styles\ReactStyle.cs" />
+    <Compile Include="Styles\StyleFactory.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Bridge, Version=1.14.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/Bridge.React/Styles/ReactStyle.cs
+++ b/Bridge.React/Styles/ReactStyle.cs
@@ -1,0 +1,38 @@
+﻿using Bridge;
+using Bridge.Html5;
+using Bridge.React;
+
+namespace Bridge.React
+{
+    /// <summary>
+    /// This class defines the properties of the inline styles you can add to react elements
+    /// </summary>
+    [ObjectLiteral]
+    public class ReactStyle : CSSStyleDeclaration
+    { 
+        public new Any<string, int> Height { get; set; }
+        public new Any<string, int> Width { get; set; }
+        public new Any<string, int> FontSize { get; set; }
+        public new Any<string, int> BorderRadius { get; set; }
+        public new Any<string, int> MinWidth { get; set; }
+        public new Any<string, int> MaxWidth { get; set; }
+        public new Any<string, int> MinHeight { get; set; }
+        public new Any<string, int> MaxHeight { get; set; }
+        public new Any<string, int> Margin { get; set; }
+        public new Any<string, int> MarginLeft { get; set; }
+        public new Any<string, int> MarginRight { get; set; }
+        public new Any<string, int> MarginTop { get; set; }
+        public new Any<string, int> MarginBottom { get; set; }
+        public new Any<string, int> Padding { get; set; }
+        public new Any<string, int> PaddingLeft { get; set; }
+        public new Any<string, int> PaddingRight { get; set; }
+        public new Any<string, int> PaddingTop { get; set; }
+        public new Any<string, int> PaddingBottom { get; set; }
+        public new Any<string, int> Top { get; set; }
+        public new Any<string, int> Bottom { get; set; }
+        public new Any<string, int> Left { get; set; }
+        public new Any<string, int> Right { get; set; }
+        public new Any<string, double> Opacity { get; set; }
+        public Float Float { get; set; }
+    }
+}

--- a/Bridge.React/Styles/StyleFactory.cs
+++ b/Bridge.React/Styles/StyleFactory.cs
@@ -8,8 +8,23 @@ namespace Bridge.React
 {
     public static class Style
     {
-        [Template("Object.assign(JSON.parse(JSON.stringify({0})), JSON.parse(JSON.stringify({1})))")]
-        public extern static ReactStyle MergeWith(this ReactStyle baseStyle, ReactStyle other);
+        public static ReactStyle MergeWith(this ReactStyle source, ReactStyle other)
+        {
+            var merged = Script.Write<ReactStyle>("{ }");
+            /*@
+            if (source) {
+                for (var i in source) {
+                    merged[i] = source[i];
+                }
+            }
+            if (other) {
+                for (var i in other) {
+                    merged[i] = other[i];
+                }
+            }
+            */
+            return merged;
+        }
 
         public static ReactStyle Height(Any<string, int> height)
         {

--- a/Bridge.React/Styles/StyleFactory.cs
+++ b/Bridge.React/Styles/StyleFactory.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bridge.React
+{
+    public static class Style
+    {
+        [Template("Object.assign(JSON.parse(JSON.stringify({0})), JSON.parse(JSON.stringify({1})))")]
+        public extern static ReactStyle MergeWith(this ReactStyle baseStyle, ReactStyle other);
+
+        public static ReactStyle Height(Any<string, int> height)
+        {
+            return new ReactStyle { Height = height };
+        }
+        public static ReactStyle Height(this ReactStyle style, Any<string, int> height)
+        {
+            style.Height = height;
+            return style;
+        }
+
+        public static ReactStyle Width(Any<string, int> width)
+        {
+            return new ReactStyle { Width = width };
+        }
+        public static ReactStyle Width(this ReactStyle style, Any<string, int> width)
+        {
+            style.Width = width;
+            return style;
+        } 
+
+
+        public static ReactStyle FontSize(Any<string, int> fontSize)
+        {
+            return new ReactStyle
+            {
+                FontSize = fontSize
+            };
+        }
+        public static ReactStyle FontSize(this ReactStyle style, Any<string, int> fontSize)
+        {
+            style.FontSize = fontSize;
+            return style;
+        }
+
+        public static ReactStyle Margin(Any<string, int> margin)
+        {
+            return new ReactStyle { Margin = margin };
+        }
+        public static ReactStyle Margin(Any<string, int> top, Any<string, int> right, Any<string, int> bottom, Any<string, int> left)
+        {
+            return new ReactStyle
+            {
+                MarginTop = top,
+                MarginLeft = left,
+                MarginRight = right,
+                MarginBottom = bottom
+            };
+        }
+
+        public static ReactStyle Margin(this ReactStyle style, Any<string, int> margin)
+        {
+            style.Margin = margin;
+            return style;
+        }
+
+        public static ReactStyle Margin(this ReactStyle style, Any<string, int> top, Any<string, int> right, Any<string, int> bottom, Any<string, int> left)
+        {
+            style.MarginTop = top;
+            style.MarginLeft = left;
+            style.MarginRight = right;
+            style.MarginBottom = bottom;
+            return style;
+        }
+
+        public static ReactStyle Padding(Any<string, int> padding)
+        {
+            return new ReactStyle { Padding = padding };
+        }
+        public static ReactStyle Padding(Any<string, int> top, Any<string, int> right, Any<string, int> bottom, Any<string, int> left)
+        {
+            return new ReactStyle
+            {
+                PaddingTop = top,
+                PaddingLeft = left,
+                PaddingRight = right,
+                PaddingBottom = bottom
+            };
+        }
+
+        public static ReactStyle Padding(this ReactStyle style, Any<string, int> padding)
+        {
+            style.Padding = padding;
+            return style;
+        }
+
+        public static ReactStyle Padding(this ReactStyle style, Any<string, int> top, Any<string, int> right, Any<string, int> bottom, Any<string, int> left)
+        {
+            style.PaddingTop = top;
+            style.PaddingLeft = left;
+            style.PaddingRight = right;
+            style.PaddingBottom = bottom;
+            return style;
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds inline styling support for the `Style` property on `ReactElement` attributes. 
### Definition
It defines a `ReactStyle` class  that inherits from `CSSStyleDeclaration`. Because styles in React are simple javascript object literals, `[ObjectLiteral]` is added to `ReactStyle`. However, some properties on `ReactStyle` hide the original properties for ease of use. For example, the Height property is originally defined to be of type `string` on the `CSSStyleDeclaration` object, which is correct because then you can postfix the height value with `px` but in the case of React style objects, it does that for us so the new property becomes 
```public new Any<string, int> Height { get; set; }```. 
### Factory functions
To make the construction of style objects easy, I have added a couple of helper functions that come in pairs. It goes like this:
```
// this is a normal static function that will return a new ReactStyle.
public static ReactStyle Height(Any<string, int> height)
{
    return new ReactStyle { Height = height };
}
// this is an extension method that allows fluent mutation on the incoming ReactStyle instance.
public static ReactStyle Height(this ReactStyle style, Any<string, int> height)
{
    style.Height = height;
    return style;
}
```
These combinations allow fleunt chaining, i.e.
```
var divStyle = Style.Margin(5).Padding(5).FontSize(18).Color("white");
```
For me, it was most convenient to define the styles in a static class as demonstrated with the TodoApp. TodoApp is now fully self-contained with all its styles in one place.
### Reuseablity
Composing new styles out of existing ones is also possible using the extension function `MergeWith`, to illustrate what it does, here is the code used with TodoApp:
```
private static readonly ReactStyle ButtonBase = new ReactStyle
{
    FontWeight = "900",
    Margin = 10,
    MinHeight = 40,
    MinWidth = 40
};

public static readonly ReactStyle RemoveButton = ButtonBase.MergeWith(new ReactStyle
{
    BackgroundColor = "#e03242",
    Color = "white",
    Border = "1px solid white",
    BorderRadius = 5
});
```
This is achieved using the native `Object.assign` function that merges two objects into one. My first try was to define it like this:
```
[Template("Object.assign({0}, {1})")]
public extern static ReactStyle MergeWith(this ReactStyle baseStyle, ReactStyle other);
```
But this mutates the objects. So when merging objects you get unexpected behaviour. Solution was to (naievely) clone the objects before merging using `JSON.parse(JSON.stringify(x))` like this:
```
[Template("Object.assign(JSON.parse(JSON.stringify({0})), JSON.parse(JSON.stringify({1})))")]
public extern static ReactStyle MergeWith(this ReactStyle baseStyle, ReactStyle other);
```

Looking forward to hear your feedback