### PR TITLE
Deprecate IDispatcher's HandleViewAction and HandleServerAction in favour of a simpler Dispatch method

### DIFF
--- a/Bridge.React/Bridge.React.csproj
+++ b/Bridge.React/Bridge.React.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Components\PureComponent.cs" />
     <Compile Include="Components\ComponentNameHelpers.cs" />
     <Compile Include="ComponentListToReactElementTranslation.cs" />
+    <Compile Include="Dispatcher\IDispatcherActionExtensions.cs" />
     <Compile Include="Dispatcher\IDispatcher.cs" />
     <Compile Include="Elements\ReactElementList.cs" />
     <Compile Include="EnumerableComponentExtensions.cs" />

--- a/Bridge.React/Dispatcher/AppDispatcher.cs
+++ b/Bridge.React/Dispatcher/AppDispatcher.cs
@@ -4,6 +4,8 @@ namespace Bridge.React
 {
 	public sealed class AppDispatcher : IDispatcher
 	{
+		// TODO: Change this to an Action<IDispatcherAction> event handler later on when removing the DispatcherMessage support altogether.
+		// It can't be changed now because consumers may be relying on the extra information given in the DispatcherMessage class.
 		private event Action<DispatcherMessage> _dispatcher;
 
 		private bool _currentDispatching;
@@ -13,13 +15,47 @@ namespace Bridge.React
 		}
 
 		/// <summary>
-		/// Actions will sent to each receiver in the same order as which the receivers called Register
+		/// Dispatches an action that will be sent to all callbacks registered with this dispatcher.
 		/// </summary>
+		/// <param name="action">The action to dispatch; may not be null.</param>
+		public void Dispatch(IDispatcherAction action)
+		{
+			if (action == null)
+				throw new ArgumentNullException(nameof(action));
+
+			// The obsolete MessageSourceOptions handling needs to stay in the meantime, so just dispatch this as any arbitrary source.
+			// Eventually this method should absorb the Dispatch(DispatcherMessage message) method's behaviour but dispatch the action
+			// directly down to the event handler without wrapping it in a DispatcherMessage.
+			Dispatch(new DispatcherMessage(MessageSourceOptions.View, action));
+		}
+
+		/// <summary>
+		/// Registers a callback to receive actions dispatched through this dispatcher.
+		/// </summary>
+		/// <param name="callback">The callback; may not be null.</param>
+		/// <remarks>
+		/// Actions will be sent to each receiver in the same order as which the receivers called Register.
+		/// </remarks>
+		public void Register(Action<IDispatcherAction> callback)
+		{
+			if (callback == null)
+				throw new ArgumentNullException(nameof(callback));
+
+			// We have to keep support for the DispatcherMessage class for now (until a breaking release is made), so the _dispatcher
+			// event handler has to take DispatcherMessages for now, and we have to wrap the callback given here.
+			_dispatcher += obsoleteDispatcherMessage => callback(obsoleteDispatcherMessage.Action);
+		}
+
+		/// <summary>
+		/// Actions will sent to each receiver in the same order as which the receivers called Register.
+		/// </summary>
+		[Obsolete("Support for Actions attributed to different sources (i.e. View vs. Server actions) will be removed from the IDispatcher interface. Use the Register(Action<IDispatcherAction>) method instead of Register(Action<DispatcherMessage>).")]
 		public void Register(Action<DispatcherMessage> callback)
 		{
 			_dispatcher += callback;
 		}
 
+		[Obsolete("Support for Actions attributed to different sources (i.e. View vs. Server actions) will be removed from the IDispatcher interface. Use the Dispatch method instead of HandleViewAction or HandleServerAction.")]
 		public void HandleViewAction(IDispatcherAction action)
 		{
 			if (action == null)
@@ -28,6 +64,7 @@ namespace Bridge.React
 			Dispatch(new DispatcherMessage(MessageSourceOptions.View, action));
 		}
 
+		[Obsolete("Support for Actions attributed to different sources (i.e. View vs. Server actions) will be removed from the IDispatcher interface. Use the Dispatch method instead of HandleViewAction or HandleServerAction.")]
 		public void HandleServerAction(IDispatcherAction action)
 		{
 			if (action == null)

--- a/Bridge.React/Dispatcher/DispatcherMessage.cs
+++ b/Bridge.React/Dispatcher/DispatcherMessage.cs
@@ -2,24 +2,25 @@
 
 namespace Bridge.React
 {
-    public sealed class DispatcherMessage
-    {
-        public DispatcherMessage(MessageSourceOptions source, IDispatcherAction action)
-        {
-            if ((source != MessageSourceOptions.Server) && (source != MessageSourceOptions.View))
-                throw new ArgumentOutOfRangeException("source");
-            if (action == null)
-                throw new ArgumentNullException("action");
+	[Obsolete("Support for Actions attributed to different sources (i.e. View vs. Server actions) will be removed from the IDispatcher interface. Use IDispatcherAction directly instead of the DispatcherMessage wrapper class.")]
+	public sealed class DispatcherMessage
+	{
+		public DispatcherMessage(MessageSourceOptions source, IDispatcherAction action)
+		{
+			if ((source != MessageSourceOptions.Server) && (source != MessageSourceOptions.View))
+				throw new ArgumentOutOfRangeException("source");
+			if (action == null)
+				throw new ArgumentNullException("action");
 
-            Source = source;
-            Action = action;
-        }
+			Source = source;
+			Action = action;
+		}
 
-        public MessageSourceOptions Source { get; private set; }
+		public MessageSourceOptions Source { get; private set; }
 
-        /// <summary>
-        /// This will never be null
-        /// </summary>
-        public IDispatcherAction Action { get; private set; }
-    }
+		/// <summary>
+		/// This will never be null
+		/// </summary>
+		public IDispatcherAction Action { get; private set; }
+	}
 }

--- a/Bridge.React/Dispatcher/DispatcherMessageExtensions.cs
+++ b/Bridge.React/Dispatcher/DispatcherMessageExtensions.cs
@@ -2,6 +2,7 @@
 
 namespace Bridge.React
 {
+	[Obsolete("Support for Actions attributed to different sources (i.e. View vs. Server actions) will be removed from the IDispatcher interface. Use IDispatcherAction directly instead of the DispatcherMessage wrapper class.")]
 	public static class DispatcherMessageExtensions
 	{
 		/// <summary>

--- a/Bridge.React/Dispatcher/IDispatcher.cs
+++ b/Bridge.React/Dispatcher/IDispatcher.cs
@@ -4,8 +4,28 @@ namespace Bridge.React
 {
 	public interface IDispatcher
 	{
+		/// <summary>
+		/// Dispatches an action that will be sent to all callbacks registered with this dispatcher.
+		/// </summary>
+		/// <param name="action">The action to dispatch; may not be null.</param>
+		void Dispatch(IDispatcherAction action);
+
+		/// <summary>
+		/// Registers a callback to receive actions dispatched through this dispatcher.
+		/// </summary>
+		/// <param name="callback">The callback; may not be null.</param>
+		/// <remarks>
+		/// Actions will be sent to each receiver in the same order as which the receivers called Register.
+		/// </remarks>
+		void Register(Action<IDispatcherAction> callback);
+
+		[Obsolete("Support for Actions attributed to different sources (i.e. View vs. Server actions) will be removed from the IDispatcher interface. Use the Dispatch method instead of HandleViewAction or HandleServerAction.")]
 		void HandleServerAction(IDispatcherAction action);
+
+		[Obsolete("Support for Actions attributed to different sources (i.e. View vs. Server actions) will be removed from the IDispatcher interface. Use the Dispatch method instead of HandleViewAction or HandleServerAction.")]
 		void HandleViewAction(IDispatcherAction action);
+
+		[Obsolete("Support for Actions attributed to different sources (i.e. View vs. Server actions) will be removed from the IDispatcher interface. Use the Register(Action<IDispatcherAction>) method instead of Register(Action<DispatcherMessage>).")]
 		void Register(Action<DispatcherMessage> callback);
 	}
 }

--- a/Bridge.React/Dispatcher/IDispatcherActionExtensions.cs
+++ b/Bridge.React/Dispatcher/IDispatcherActionExtensions.cs
@@ -1,0 +1,129 @@
+﻿using System;
+
+namespace Bridge.React
+{
+	public static class IDispatcherActionExtensions
+	{
+		/// <summary>
+		/// This will execute the specified callback with a non-null reference if the current IDispatcherAction matches type T.
+		/// It will never call the work action with a null reference and it will never return a null reference. It will throw an exception
+		/// for a null IDispatcherAction or null work reference.
+		/// </summary>
+		public static IMatchDispatcherActions If<T>(this IDispatcherAction action, Action<T> work) where T : class, IDispatcherAction
+		{
+			return new DispatcherActionMatcher(action).Else(work);
+		}
+
+		/// <summary>
+		/// This will execute the specified callback with a non-null reference if the current IDispatcherAction matches type T and
+		/// if that instance of T meets the specified conditions. It will never call the work action with a null reference and it will never
+		/// return a null reference. It will throw an exception for a null IDispatcherAction, null condition or null work reference.
+		/// </summary>
+		public static IMatchDispatcherActions If<T>(this IDispatcherAction action, Func<T, bool> condition, Action<T> work) where T : class, IDispatcherAction
+		{
+			return new DispatcherActionMatcher(action).Else(condition, work);
+		}
+
+		public interface IMatchDispatcherActions
+		{
+			/// <summary>
+			/// This will execute the specified callback with a non-null reference if the current IDispatcherAction matches type T.
+			/// It will never call the work action with a null reference and it will never return a null reference. It will throw an exception
+			/// for a null work reference.
+			/// </summary>
+			IMatchDispatcherActions Else<T>(Action<T> work) where T : class, IDispatcherAction;
+
+			/// <summary>
+			/// This will execute the specified callback with a non-null reference if the current IDispatcherAction matches type T and
+			/// if that instance of T meets the specified conditions. It will never call the work action with a null reference and it will never
+			/// return a null reference. It will throw an exception for a null IDispatcherAction, null condition or null work reference.
+			/// </summary>
+			IMatchDispatcherActions Else<T>(Func<T, bool> condition, Action<T> work) where T : class, IDispatcherAction;
+
+			/// <summary>
+			/// If any IDispatcherAction has been matched then the specified callback will be executed, if not then it will not be.
+			/// This will throw an exception for a null work reference.
+			/// </summary>
+			void IfAnyMatched(Action work);
+		}
+
+		private class DispatcherActionMatcher : IMatchDispatcherActions
+		{
+			private readonly IDispatcherAction _action;
+			public DispatcherActionMatcher(IDispatcherAction action)
+			{
+				if (action == null)
+					throw new ArgumentNullException(nameof(action));
+				_action = action;
+			}
+
+			public IMatchDispatcherActions Else<T>(Action<T> work) where T : class, IDispatcherAction
+			{
+				return ElseWithOptionalCondition(null, work);
+			}
+
+			public IMatchDispatcherActions Else<T>(Func<T, bool> condition, Action<T> work) where T : class, IDispatcherAction
+			{
+				if (condition == null)
+					throw new ArgumentNullException(nameof(condition));
+
+				return ElseWithOptionalCondition(condition, work);
+			}
+
+			private IMatchDispatcherActions ElseWithOptionalCondition<T>(Func<T, bool> optionalCondition, Action<T> work) where T : class, IDispatcherAction
+			{
+				if (work == null)
+					throw new ArgumentNullException(nameof(work));
+
+				var actionOfDesiredType = _action as T;
+				if ((actionOfDesiredType == null) || ((optionalCondition != null) && !optionalCondition(actionOfDesiredType)))
+					return this;
+
+				work(actionOfDesiredType);
+				return MatchFoundSoMatchNoMoreDispatcherActionMatcher.Instance;
+			}
+
+			public void IfAnyMatched(Action work)
+			{
+				if (work == null)
+					throw new ArgumentNullException(nameof(work));
+
+				// Do nothing here - there has been no IDispatcherAction successfully matched by this point (if there had been then
+				// we would have returned a MatchFoundSoMatchNoMoreDispatcherActionMatcher)
+			}
+		}
+
+		private class MatchFoundSoMatchNoMoreDispatcherActionMatcher : IMatchDispatcherActions
+		{
+			public static MatchFoundSoMatchNoMoreDispatcherActionMatcher Instance = new MatchFoundSoMatchNoMoreDispatcherActionMatcher();
+
+			private MatchFoundSoMatchNoMoreDispatcherActionMatcher() { }
+
+			public IMatchDispatcherActions Else<T>(Action<T> work) where T : class, IDispatcherAction
+			{
+				if (work == null)
+					throw new ArgumentNullException(nameof(work));
+				return this;
+			}
+
+			public IMatchDispatcherActions Else<T>(Func<T, bool> condition, Action<T> work) where T : class, IDispatcherAction
+			{
+				if (condition == null)
+					throw new ArgumentNullException(nameof(condition));
+				if (work == null)
+					throw new ArgumentNullException(nameof(work));
+				return this;
+			}
+
+			public void IfAnyMatched(Action work)
+			{
+				if (work == null)
+					throw new ArgumentNullException(nameof(work));
+
+				// This class is only used if an IDispatcherAction has been succesfully matched, so any calls to IfMatched on this
+				// class should result in the if-successful work being executed
+				work();
+			}
+		}
+	}
+}

--- a/Bridge.React/Dispatcher/MessageSourceOptions.cs
+++ b/Bridge.React/Dispatcher/MessageSourceOptions.cs
@@ -1,8 +1,11 @@
-﻿namespace Bridge.React
+﻿using System;
+
+namespace Bridge.React
 {
-    public enum MessageSourceOptions
-    {
-        Server,
-        View
-    }
+	[Obsolete("Support for Actions attributed to different sources (i.e. View vs. Server actions) will be removed from the IDispatcher interface. MessageSourceOptions should no longer be used.")]
+	public enum MessageSourceOptions
+	{
+		Server,
+		View
+	}
 }


### PR DESCRIPTION
This pull request obsoletes the IDispatcher's HandleViewAction and HandleServerAction in favour of a single Dispatch method that doesn't attribute actions to any particular source. This obsoletes the DispatcherMessage class and its friends - callbacks should now be Registered to accept IDispatcherAction directly, instead of the DispatcherMessage wrapper class.

The distinction of "view actions" vs. "server actions" doesn't seem to be useful in practice and this distinction also doesn't exist in Facebook's official Flux project; https://github.com/facebook/flux/blob/master/src/Dispatcher.js

The changes here should be non-breaking. Existing interfaces and implementations have only been adorned with [Obsolete] and the new functionality that has been added shouldn't interfere with old functionality.