### PR TITLE
Fix AutoComplete/AutoFocus/AutoSave prop casing

### DIFF
--- a/Bridge.React/Attributes/InputAttributes.cs
+++ b/Bridge.React/Attributes/InputAttributes.cs
@@ -8,11 +8,8 @@ namespace Bridge.React
 	{
 		public string Accept { private get; set; }
 		public string Alt { private get; set; }
-		[Name("autocomplete")]
 		public AutoComplete AutoComplete { private get; set; }
-		[Name("autofocus")]
 		public bool AutoFocus { private get; set; }
-		[Name("autosave")]
 		public bool AutoSave { private get; set; }
 		public bool Checked { private get; set; }
 		public bool DefaultChecked { private get; set; }


### PR DESCRIPTION
React wants these props camel-case but the code here was forcing them to lower-case.

Here were the errors that happened before:
```
Warning: Unknown DOM property autocomplete. Did you mean autoComplete?
    in input (created by ExampleContainer)
    in label (created by ExampleContainer)
    in div (created by ExampleContainer)
    in div (created by ExampleContainer)
    in ExampleContainer  react.js:20483:9
Warning: Unknown DOM property autosave. Did you mean autoSave?
    in input (created by ExampleContainer)
    in label (created by ExampleContainer)
    in div (created by ExampleContainer)
    in div (created by ExampleContainer)
    in ExampleContainer  react.js:20483:9
"Warning: Unknown prop `autofocus` on <input> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop
    in input (created by ExampleContainer)
    in label (created by ExampleContainer)
    in div (created by ExampleContainer)
    in div (created by ExampleContainer)
    in ExampleContainer"
```