### PR TITLE
Add support for ReactDOM.unmountComponentAtNode

### DIFF
--- a/Bridge.React/React.cs
+++ b/Bridge.React/React.cs
@@ -1,12 +1,44 @@
-﻿using Bridge.Html5;
+﻿using System;
+using Bridge.Html5;
 
 namespace Bridge.React
 {
-    [Name("ReactDOM")]
-    [External]
-    public static class React
-    {
-        [Name("render")]
-        public extern static void Render(ReactElement element, Element container);
-    }
+	[Name("ReactDOM")]
+	[External]
+	public static class React
+	{
+		/// <summary>
+		/// Render a React element into the DOM in the supplied container.
+		/// 
+		/// If the React element was previously rendered into container, this will perform an update on it and
+		/// only mutate the DOM as necessary to reflect the latest React element.
+		/// </summary>
+		// NOTE: ReactDOM.render actually returns "a reference to the component (or returns null for stateless components)",
+		// but I'm not quite sure what type to use for those (they're not the same as the ReactElement passed in, and for
+		// DOM HTML elements they return those HTML elements themselves).
+		[Name("render")]
+		public extern static void Render(ReactElement element, Element container);
+
+		/// <summary>
+		/// Render a React element into the DOM in the supplied container.
+		/// 
+		/// If the React element was previously rendered into container, this will perform an update on it and
+		/// only mutate the DOM as necessary to reflect the latest React element.
+		/// 
+		/// The provided callback will be executed after the component is rendered or updated.
+		/// </summary>
+		// NOTE: ReactDOM.render actually returns "a reference to the component (or returns null for stateless components)",
+		// but I'm not quite sure what type to use for those (they're not the same as the ReactElement passed in, and for
+		// DOM HTML elements they return those HTML elements themselves).
+		[Name("render")]
+		public extern static void Render(ReactElement element, Element container, Action callback);
+
+		/// <summary>
+		/// Remove a mounted React component from the DOM and clean up its event handlers and state.
+		/// If no component was mounted in the container, calling this function does nothing.
+		/// Returns true if a component was unmounted and false if there was no component to unmount.
+		/// </summary>
+		[Name("unmountComponentAtNode")]
+		public extern static bool UnmountComponentAtNode(Element container);
+	}
 }


### PR DESCRIPTION
[`ReactDOM.unmountComponentAtNode`](https://facebook.github.io/react/docs/react-dom.html#unmountcomponentatnode) is the opposite of [`ReactDOM.render`](https://facebook.github.io/react/docs/react-dom.html#render).

This'll unmount and clean up components properly and remove their markup.

This is very useful for unit testing where you want to clean up React-rendered trees after tests complete. (As opposed to hacking them out with `container.InnerHTML = "";`)

I've also added the overload of `ReactDOM.render` that supports calling a callback after the components are rendered or updated. This may also be possibly useful for unit testing scenarios, but I included it mainly for completeness.

**EDIT:** There's also [`ReactDOM.findDOMNode`](https://facebook.github.io/react/docs/react-dom.html#finddomnode) but I haven't needed that for my use cases, and it seems to be discouraged quite a bit in the React docs. (Maybe this one could be useful for unit testing too, who knows?)