### PR TITLE
Support component refs

### DIFF
--- a/Bridge.React.Analyser/Analyser.Test.NonBridgeBuild/Analyser.Test.NonBridgeBuild.csproj
+++ b/Bridge.React.Analyser/Analyser.Test.NonBridgeBuild/Analyser.Test.NonBridgeBuild.csproj
@@ -197,6 +197,12 @@
     <Compile Include="..\..\Bridge.React\Components\WrappedValueWithKey.cs">
       <Link>Components\WrappedValueWithKey.cs</Link>
     </Compile>
+    <Compile Include="..\..\Bridge.React\Components\WrappedValueWithKeyAndRef.cs">
+      <Link>Components\WrappedValueWithKeyAndRef.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Bridge.React\Components\WrappedValueWithRef.cs">
+      <Link>Components\WrappedValueWithRef.cs</Link>
+    </Compile>
     <Compile Include="..\..\Bridge.React\DOM.cs">
       <Link>DOM.cs</Link>
     </Compile>

--- a/Bridge.React.nuspec
+++ b/Bridge.React.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Bridge.React</id>
     <title>Bridge.React</title>
-    <version>3.1.3</version>
+    <version>3.1.4</version>
     <authors>ProductiveRage</authors>
     <owners>ProductiveRage</owners>
     <licenseUrl>https://github.com/ProductiveRage/Bridge.React/blob/master/LICENSE</licenseUrl>

--- a/Bridge.React/Bridge.React.csproj
+++ b/Bridge.React/Bridge.React.csproj
@@ -44,6 +44,8 @@
     <Compile Include="Attributes\RawHtml.cs" />
     <Compile Include="Attributes\ReactDomElementAttributes.cs" />
     <Compile Include="Attributes\DomElementWithEventsAttributes.cs" />
+    <Compile Include="Components\WrappedValueWithKeyAndRef.cs" />
+    <Compile Include="Components\WrappedValueWithRef.cs" />
     <Compile Include="Components\WrappedValueWithKey.cs" />
     <Compile Include="Components\WrappedValue.cs" />
     <Compile Include="Components\ReactComponentClassCreator.cs" />

--- a/Bridge.React/Components/Component.cs
+++ b/Bridge.React/Components/Component.cs
@@ -32,7 +32,7 @@ namespace Bridge.React
 			// component must be contained within the props (and state, where appropriate). Note: In most cases where children are specified as a params array, we don't want
 			// the "children require unique keys" warning from React (you don't get it if you call DOM.Div(null, "Item1", "Item2"), so we don't want it in most cases here
 			// either - to achieve this, we prepare an arguments array and pass that to React.createElement in an "apply" call.
-			Array createElementArgs = new object[] { reactComponentClass, ComponentPropsHelpers.WrapProps(props) };
+			Array createElementArgs = new object[] { reactComponentClass, ComponentPropsHelpers.WrapProps<Component<TProps, TState>, TProps>(props) };
 			if (children != null)
 				createElementArgs = createElementArgs.Concat(children);
 			_reactElement = Script.Write<ReactElement>("React.createElement.apply(null, createElementArgs)");

--- a/Bridge.React/Components/PureComponent.cs
+++ b/Bridge.React/Components/PureComponent.cs
@@ -33,7 +33,7 @@ namespace Bridge.React
 			// be contained within the props. Note: In most cases where children are specified as a params array, we don't want the "children require unique keys" warning
 			// from React (you don't get it if you call DOM.Div(null, "Item1", "Item2"), so we don't want it in most cases here either - to achieve this, we prepare an
 			// arguments array and pass that to React.createElement in an "apply" call.
-			Array createElementArgs = new object[] { reactComponentClass, ComponentPropsHelpers.WrapProps(props) };
+			Array createElementArgs = new object[] { reactComponentClass, ComponentPropsHelpers.WrapProps<PureComponent<TProps>, TProps>(props) };
 			if (children != null)
 				createElementArgs = createElementArgs.Concat(children);
 			_reactElement = Script.Write<ReactElement>("React.createElement.apply(null, createElementArgs)");

--- a/Bridge.React/Components/StatelessComponent.cs
+++ b/Bridge.React/Components/StatelessComponent.cs
@@ -25,7 +25,7 @@ namespace Bridge.React
 			// we render. In most cases where children are specified as a params array, we don't want the "children require unique keys" warning from React (you
 			// don't get it if you call DOM.Div(null, "Item1", "Item2"), so we don't want it in most cases here either - to achieve this, we prepare an arguments
 			// array and pass that to React.createElement in an "apply" call. Similar techniques are used in the stateful component.
-			Array createElementArgs = new object[] { reactStatelessRenderFunction, ComponentPropsHelpers.WrapProps(props) };
+			Array createElementArgs = new object[] { reactStatelessRenderFunction, ComponentPropsHelpers.WrapProps<StatelessComponent<TProps>, TProps>(props) };
 			if (children != null)
 				createElementArgs = createElementArgs.Concat(children);
 			_reactElement = Script.Write<ReactElement>("React.createElement.apply(null, createElementArgs)");

--- a/Bridge.React/Components/StaticComponent.cs
+++ b/Bridge.React/Components/StaticComponent.cs
@@ -36,7 +36,7 @@ namespace Bridge.React
 				renderer.$$componentClass = componentClass;
 			}
 			*/
-			var wrappedProps = ComponentPropsHelpers.WrapProps(props);
+			var wrappedProps = ComponentPropsHelpers.WrapProps<Func<TProps, ReactElement>, TProps>(props);
 			return Script.Write<ReactElement>("React.createElement(componentClass, wrappedProps)");
 		}
 
@@ -49,7 +49,7 @@ namespace Bridge.React
 			var namedScopeBoundFunction;
 			eval("namedScopeBoundFunction = function " + renderer.name + "(props) { return renderer(props ? props.value : props); };");
 			*/
-			var wrappedProps = ComponentPropsHelpers.WrapProps(props);
+			var wrappedProps = ComponentPropsHelpers.WrapProps<Func<TProps, ReactElement>, TProps>(props);
 			return Script.Write<ReactElement>("React.createElement(namedScopeBoundFunction, wrappedProps)");
 		}
 

--- a/Bridge.React/Components/WrappedValue.cs
+++ b/Bridge.React/Components/WrappedValue.cs
@@ -1,8 +1,8 @@
 ﻿namespace Bridge.React
 {
 	[ObjectLiteral(ObjectCreateMode.Plain)]
-	internal class WrappedValue<T>
+	internal class WrappedValue<TValue>
 	{
-		public T Value { get; set; }
+		public TValue Value { get; set; }
 	}
 }

--- a/Bridge.React/Components/WrappedValueWithKey.cs
+++ b/Bridge.React/Components/WrappedValueWithKey.cs
@@ -1,7 +1,7 @@
 ﻿namespace Bridge.React
 {
 	[ObjectLiteral(ObjectCreateMode.Plain)]
-	internal class WrappedValueWithKey<T> : WrappedValue<T>
+	internal class WrappedValueWithKey<TValue> : WrappedValue<TValue>
 	{
 		public Union<string, int> Key { get; set; }
 	}

--- a/Bridge.React/Components/WrappedValueWithKeyAndRef.cs
+++ b/Bridge.React/Components/WrappedValueWithKeyAndRef.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Bridge.React
+{
+	[ObjectLiteral(ObjectCreateMode.Plain)]
+	internal class WrappedValueWithKeyAndRef<TValue, TComponent> : WrappedValue<TValue>
+	{
+		public Union<string, int> Key { get; set; }
+
+		public Action<TComponent> Ref { get; set; }
+	}
+}

--- a/Bridge.React/Components/WrappedValueWithRef.cs
+++ b/Bridge.React/Components/WrappedValueWithRef.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Bridge.React
+{
+	[ObjectLiteral(ObjectCreateMode.Plain)]
+	internal class WrappedValueWithRef<TValue, TComponent> : WrappedValue<TValue>
+	{
+		public Action<TComponent> Ref { get; set; }
+	}
+}

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
 
 [assembly: AssemblyCopyright("Copyright © ProductiveRage 2017")]
-[assembly: AssemblyVersion("3.1.3.0")]
-[assembly: AssemblyFileVersion("3.1.3.0")]
+[assembly: AssemblyVersion("3.1.4.0")]
+[assembly: AssemblyFileVersion("3.1.4.0")]


### PR DESCRIPTION
This change makes sure the `Ref` property is available directly on the component props as `Key` is already so React will make use of that callback to expose instances of **components** when mounted (as is already possible for DOM elements when they mount).

This allows scenarios that aren't as simple as changing props to cause state changes. For example, allowing a parent component to trigger a Focus and Click of a child component, like so:

**ParentComponent.cs**
```c#
public override ReactElement Render()
{
    ActionMenu mountedActionMenu = null;

    return DOM.Div(
        null,
        DOM.Button(
            new ButtonAttributes
            {
                onClick = ev => mountedActionMenu.Trigger()
            },
            "Trigger click"
        ),
        new ActionMenu(
            model: state.ActionMenuModel,
            onChange: newModel => props.Dispatcher.Dispatch(
                new ActionMenuPageModelChanged(state.With(_ => _.ActionMenuModel, newModel))
            ),
            @ref: instance => mountedActionMenu = instance
        )
    );
}
```

The `@ref` syntax is required here because `ref` is a reserved keyword. It's a bit unfortunate, but I think it's ok because Refs shouldn't be overused.

React doc: https://reactjs.org/docs/refs-and-the-dom.html