### PR TITLE
Add support for the "draggable" attribute on HTMLElement

### DIFF
--- a/Bridge.React.nuspec
+++ b/Bridge.React.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Bridge.React</id>
     <title>Bridge.React</title>
-    <version>3.1.5</version>
+    <version>3.1.6</version>
     <authors>ProductiveRage</authors>
     <owners>ProductiveRage</owners>
     <licenseUrl>https://github.com/ProductiveRage/Bridge.React/blob/master/LICENSE</licenseUrl>

--- a/Bridge.React/Attributes/DomElementsAttributes.cs
+++ b/Bridge.React/Attributes/DomElementsAttributes.cs
@@ -11,6 +11,7 @@ namespace Bridge.React
 		public string AccessKey { private get; set; }
 		public ContentEditable ContentEditable { private get; set; }
 		public TextDirection Dir { private get; set; }
+		public bool Draggable { private get; set; }
 		public string Lang { private get; set; }
 		public int TabIndex { private get; set; }
 		public string Title { private get; set; }

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
 
 [assembly: AssemblyCopyright("Copyright © ProductiveRage 2017")]
-[assembly: AssemblyVersion("3.1.5.0")]
-[assembly: AssemblyFileVersion("3.1.5.0")]
+[assembly: AssemblyVersion("3.1.6.0")]
+[assembly: AssemblyFileVersion("3.1.6.0")]


### PR DESCRIPTION
This adds support for the global `draggable` attribute on HTMLElement. This is required for marking an arbitrary element as being draggable (otherwise only images, links, and selections can be draggable).

https://html.spec.whatwg.org/multipage/dnd.html#the-draggable-attribute
https://html.spec.whatwg.org/multipage/dom.html#elements-in-the-dom:dom-draggable