### PR TITLE
Mark legacy KeyboardEvent attributes as Obsolete

### DIFF
--- a/Bridge.React.nuspec
+++ b/Bridge.React.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Bridge.React</id>
     <title>Bridge.React</title>
-    <version>3.1.7</version>
+    <version>3.1.8</version>
     <authors>ProductiveRage</authors>
     <owners>ProductiveRage</owners>
     <licenseUrl>https://github.com/ProductiveRage/Bridge.React/blob/master/LICENSE</licenseUrl>

--- a/Bridge.React/Events/KeyboardEvent.cs
+++ b/Bridge.React/Events/KeyboardEvent.cs
@@ -1,4 +1,5 @@
-﻿using Bridge.Html5;
+﻿using System;
+using Bridge.Html5;
 
 namespace Bridge.React
 {
@@ -9,15 +10,18 @@ namespace Bridge.React
 		private KeyboardEvent() { }
 
 		public readonly bool AltKey;
+		[Obsolete("KeyboardEvent.CharCode is obsolete. Please use KeyboardEvent.Key instead. (https://www.w3.org/TR/uievents/#legacy-key-attributes)")]
 		public readonly int CharCode;
 		public readonly bool CtrlKey;
 		public readonly string Key;
+		[Obsolete("KeyboardEvent.KeyCode is obsolete. Please use KeyboardEvent.Key instead. (https://www.w3.org/TR/uievents/#legacy-key-attributes)")]
 		public readonly int KeyCode;
 		public readonly string Locale;
 		public readonly int Location;
 		public readonly bool MetaKey;
 		public readonly bool Repeat;
 		public readonly bool ShiftKey;
+		[Obsolete("KeyboardEvent.Which is obsolete. Please use KeyboardEvent.Key instead. (https://www.w3.org/TR/uievents/#legacy-key-attributes)")]
 		public readonly int Which;
 
 		[External]

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
 
 [assembly: AssemblyCopyright("Copyright © ProductiveRage 2017")]
-[assembly: AssemblyVersion("3.1.7.0")]
-[assembly: AssemblyFileVersion("3.1.7.0")]
+[assembly: AssemblyVersion("3.1.8.0")]
+[assembly: AssemblyFileVersion("3.1.8.0")]


### PR DESCRIPTION
To reinforce that developers shouldn't make use of these legacy `KeyboardEvent` properties any more, this change marks them with the `Obsolete` attribute.

**Sources:**
* https://www.w3.org/TR/uievents/#legacy-key-attributes
* https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/charCode
* https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
* https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/which