### PR TITLE
Added support for Aria-* attributes

### DIFF
--- a/Bridge.React.Examples/TodoApp.cs
+++ b/Bridge.React.Examples/TodoApp.cs
@@ -27,13 +27,7 @@ namespace Bridge.React.Examples
 				DOM.Input(new InputAttributes
 				{
 					Value = state.InputValue,
-					OnChange = e => SetState(state.With(_ => _.InputValue, e.CurrentTarget.Value)),
-                    Data = new {
-                        my_custom_value = "custom",
-                    },
-                    Aria = new {
-                        hidden = "true",
-                    },
+					OnChange = e => SetState(state.With(_ => _.InputValue, e.CurrentTarget.Value))
 				}),
 				DOM.Button(
 					new ButtonAttributes

--- a/Bridge.React.Examples/TodoApp.cs
+++ b/Bridge.React.Examples/TodoApp.cs
@@ -27,7 +27,13 @@ namespace Bridge.React.Examples
 				DOM.Input(new InputAttributes
 				{
 					Value = state.InputValue,
-					OnChange = e => SetState(state.With(_ => _.InputValue, e.CurrentTarget.Value))
+					OnChange = e => SetState(state.With(_ => _.InputValue, e.CurrentTarget.Value)),
+                    Data = new {
+                        my_custom_value = "custom",
+                    },
+                    Aria = new {
+                        hidden = "true",
+                    },
 				}),
 				DOM.Button(
 					new ButtonAttributes

--- a/Bridge.React.Tests/AriaAttributeTests.cs
+++ b/Bridge.React.Tests/AriaAttributeTests.cs
@@ -4,11 +4,11 @@ using static Bridge.QUnit.QUnit;
 
 namespace Bridge.React.Tests
 {
-	public static class DataAttributeTests
+	public static class AriaAttributeTests
 	{
 		public static void RunTests()
 		{
-			Module("DataAttribute Tests");
+			Module("AriaAttribute Tests");
 
 			Test("DOM.Div with null attributes", assert =>
 			{
@@ -23,7 +23,7 @@ namespace Bridge.React.Tests
 				);
 			});
 
-			Test("DOM.Div with ClassName-only attributes (no data attributes)", assert =>
+			Test("DOM.Div with ClassName-only attributes (no aria attributes)", assert =>
 			{
 				var done = assert.Async();
 				TestComponentMounter.Render(
@@ -36,11 +36,11 @@ namespace Bridge.React.Tests
 				);
 			});
 
-			Test("DOM.Div with ClassName and empty data value", assert =>
+			Test("DOM.Div with ClassName and empty aria value", assert =>
 			{
 				var done = assert.Async();
 				TestComponentMounter.Render(
-					DOM.Div(new Attributes { ClassName = "test", Data = null }, "Hello"),
+					DOM.Div(new Attributes { ClassName = "test", Aria = null }, "Hello"),
 					container => {
 						assert.Ok(true); // Only making sure that a null attributes references doesn't break thing (so no need to check markup)
 						done();
@@ -49,11 +49,11 @@ namespace Bridge.React.Tests
 				);
 			});
 
-            Test("DOM.Div with ClassName and empty aria value", assert =>
+            Test("DOM.Div with ClassName and empty data value", assert =>
             {
                 var done = assert.Async();
                 TestComponentMounter.Render(
-                    DOM.Div(new Attributes { ClassName = "test", Aria = new { } }, "Hello"),
+                    DOM.Div(new Attributes { ClassName = "test", Data = new { } }, "Hello"),
                     container => {
                         assert.Ok(true); // Only making sure that a null attributes references doesn't break thing (so no need to check markup)
                         done();
@@ -62,35 +62,35 @@ namespace Bridge.React.Tests
                 );
             });
 
-			Test("DOM.Div with ClassName and data 'toggle' value", assert =>
+			Test("DOM.Div with ClassName and aria 'toggle' value", assert =>
 			{
 				var done = assert.Async();
 				TestComponentMounter.Render(
-					DOM.Div(new Attributes { ClassName = "test", Data = new { toggle = "on" } }, "Hello"),
+					DOM.Div(new Attributes { ClassName = "test", Aria = new { toggle = "on" } }, "Hello"),
 					container =>
 					{
 						container.Remove();
 						var div = container.QuerySelector("div.test") as HTMLElement;
 						if (div == null)
 							throw new Exception("Unable to locate 'test' div");
-						assert.StrictEqual(div.GetAttribute("data-toggle"), "on");
+						assert.StrictEqual(div.GetAttribute("aria-toggle"), "on");
 						done();
 					}
 				);
 			});
 
-			Test("DOM.Div with ClassName and data 'toggle_me_on' value (to demonstrate underscore-to-hyphen string name replacement)", assert =>
+			Test("DOM.Div with ClassName and aria 'toggle_me_on' value (to demonstrate underscore-to-hyphen string name replacement)", assert =>
 			{
 				var done = assert.Async();
 				TestComponentMounter.Render(
-					DOM.Div(new Attributes { ClassName = "test", Data = new { toggle_me_on = "on" } }, "Hello"),
+					DOM.Div(new Attributes { ClassName = "test", Aria = new { toggle_me_on = "on" } }, "Hello"),
 					container =>
 					{
 						container.Remove();
 						var div = container.QuerySelector("div.test") as HTMLElement;
 						if (div == null)
 							throw new Exception("Unable to locate 'test' div");
-						assert.StrictEqual(div.GetAttribute("data-toggle-me-on"), "on");
+						assert.StrictEqual(div.GetAttribute("aria-toggle-me-on"), "on");
 						done();
 					}
 				);

--- a/Bridge.React.Tests/Bridge.React.Tests.csproj
+++ b/Bridge.React.Tests/Bridge.React.Tests.csproj
@@ -56,6 +56,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppDispatcherTests.cs" />
+    <Compile Include="AriaAttributeTests.cs" />
     <Compile Include="PropInstanceComparisonTests.cs" />
     <Compile Include="DataAttributeTests.cs" />
     <Compile Include="PureComponentTests.cs" />

--- a/Bridge.React.Tests/Tests.cs
+++ b/Bridge.React.Tests/Tests.cs
@@ -12,6 +12,7 @@ namespace Bridge.React.Tests
 			PureComponentTests.RunTests();
 			PropInstanceComparisonTests.Instance.RunTests();
 			DataAttributeTests.RunTests();
+            AriaAttributeTests.RunTests();
 			AppDispatcherTests.RunTests();
 		}
 	}

--- a/Bridge.React/Attributes/DomElementsAttributes.cs
+++ b/Bridge.React/Attributes/DomElementsAttributes.cs
@@ -24,6 +24,12 @@ namespace Bridge.React
 		/// </summary>
 		public dynamic Data { private get; set; }
 
+        /// <summary>
+        /// Any properties on this reference will be taken to form "aria-*" attributes (eg. if the Aria reference has a "hidden" property set to "true" then the attributes
+        /// passed to React will include a "aria-hidden" value with the value "true"). The properties on the Aria reference should not include the "aria-" prefix.
+        /// </summary>
+        public dynamic Aria { private get; set; }
+
 		/// <summary>
 		/// Warning: If this is used then the element may have no other child specified
 		/// </summary>

--- a/Bridge.React/DOMFactoryMethodHelpers.cs
+++ b/Bridge.React/DOMFactoryMethodHelpers.cs
@@ -11,16 +11,28 @@ namespace Bridge.React
 		public static DomElementsAttributes RewriteDataAttributes(DomElementsAttributes attributes)
 		{
 			/*@
-			if (!attributes || !attributes.hasOwnProperty("data"))
+			if (!attributes || !attributes.hasOwnProperty("data") || !attributes.hasOwnProperty("aria"))
 				return attributes;
-			
+
 			var data = attributes["data"];
+			var aria = attributes["aria"];
 			delete attributes["data"];
-			for (var name in data) {
-				if (!data.hasOwnProperty(name)) {
-					continue;
+			delete attributes["aria"];
+			if (data !== undefined) {
+				for (var name in data) {
+					if (!data.hasOwnProperty(name)) {
+						continue;
+					}
+					attributes["data-" + name.replace(/_/g, '-')] = data[name];
 				}
-				attributes["data-" + name.replace('_', '-')] = data[name];
+			}
+			if (aria !== undefined) {
+				for (var name in aria) {
+					if (!aria.hasOwnProperty(name)) {
+						continue;
+					}
+					attributes["aria-" + name.replace(/_/g, '-')] = aria[name];
+				}
 			}
 			*/
 			return attributes;

--- a/Bridge.React/DOMFactoryMethodHelpers.cs
+++ b/Bridge.React/DOMFactoryMethodHelpers.cs
@@ -11,7 +11,7 @@ namespace Bridge.React
 		public static DomElementsAttributes RewriteDataAttributes(DomElementsAttributes attributes)
 		{
 			/*@
-			if (!attributes || !attributes.hasOwnProperty("data") || !attributes.hasOwnProperty("aria"))
+			if (!attributes || (!attributes.hasOwnProperty("data") && !attributes.hasOwnProperty("aria")))
 				return attributes;
 
 			var data = attributes["data"];

--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ Alternatively, you may wish to expose the component more like a traditional clas
 			return Script.Write<ReactElement>("source");
 		}
 
+		public static implicit operator Union<ReactElement, string>(Photo source)
+		{
+			return Script.Write<ReactElement>("source");
+		}
+
 		[ObjectLiteral]
 		public sealed class Props
 		{

--- a/README.md
+++ b/README.md
@@ -188,6 +188,6 @@ This would allow you to write Bridge.NET code like this:
 	  	Document.GetElementById('main')
 	);
 
-Note the use oif Bridge.React.fixAttr() to process the properties before it is passed to the underlying class. Make sure you use this if you wish to be able to pass down expanded data- and aria- properties to the underlying component.
+Note the use of Bridge.React.fixAttr() to process the properties before it is passed to the underlying class. Make sure you use this if you wish to be able to pass down expanded data- and aria- properties to the underlying component.
 
 You may prefer one approach or the other - possibly depending upon whether you prefer to think in functions or classes and possibly depending upon the complexity of the component.


### PR DESCRIPTION
Added support for Aria-* attributes and fixed the bug related to string.replace only doing the first instance of an _ without the global option.

I did not see any unit tests for the fixAttr function, so I modified the example to test it and make sure it works (and found out the underscore replacement was broken).