### PR TITLE
Change attributes to have non private getters

### DIFF
--- a/Bridge.React.Examples/TodoApp.cs
+++ b/Bridge.React.Examples/TodoApp.cs
@@ -27,13 +27,7 @@ namespace Bridge.React.Examples
 				DOM.Input(new InputAttributes
 				{
 					Value = state.InputValue,
-					OnChange = e => SetState(state.With(_ => _.InputValue, e.CurrentTarget.Value)),
-                    Data = new {
-                        my_custom_value = "custom",
-                    },
-                    Aria = new {
-                        hidden = "true",
-                    },
+					OnChange = e => SetState(state.With(_ => _.InputValue, e.CurrentTarget.Value))
 				}),
 				DOM.Button(
 					new ButtonAttributes

--- a/Bridge.React.Examples/TodoApp.cs
+++ b/Bridge.React.Examples/TodoApp.cs
@@ -27,7 +27,13 @@ namespace Bridge.React.Examples
 				DOM.Input(new InputAttributes
 				{
 					Value = state.InputValue,
-					OnChange = e => SetState(state.With(_ => _.InputValue, e.CurrentTarget.Value))
+					OnChange = e => SetState(state.With(_ => _.InputValue, e.CurrentTarget.Value)),
+                    Data = new {
+                        my_custom_value = "custom",
+                    },
+                    Aria = new {
+                        hidden = "true",
+                    },
 				}),
 				DOM.Button(
 					new ButtonAttributes

--- a/Bridge.React.Tests/AriaAttributeTests.cs
+++ b/Bridge.React.Tests/AriaAttributeTests.cs
@@ -4,11 +4,11 @@ using static Bridge.QUnit.QUnit;
 
 namespace Bridge.React.Tests
 {
-	public static class DataAttributeTests
+	public static class AriaAttributeTests
 	{
 		public static void RunTests()
 		{
-			Module("DataAttribute Tests");
+			Module("AriaAttribute Tests");
 
 			Test("DOM.Div with null attributes", assert =>
 			{
@@ -23,7 +23,7 @@ namespace Bridge.React.Tests
 				);
 			});
 
-			Test("DOM.Div with ClassName-only attributes (no data attributes)", assert =>
+			Test("DOM.Div with ClassName-only attributes (no aria attributes)", assert =>
 			{
 				var done = assert.Async();
 				TestComponentMounter.Render(
@@ -36,11 +36,11 @@ namespace Bridge.React.Tests
 				);
 			});
 
-			Test("DOM.Div with ClassName and empty data value", assert =>
+			Test("DOM.Div with ClassName and empty aria value", assert =>
 			{
 				var done = assert.Async();
 				TestComponentMounter.Render(
-					DOM.Div(new Attributes { ClassName = "test", Data = null }, "Hello"),
+					DOM.Div(new Attributes { ClassName = "test", Aria = null }, "Hello"),
 					container => {
 						assert.Ok(true); // Only making sure that a null attributes references doesn't break thing (so no need to check markup)
 						done();
@@ -49,11 +49,11 @@ namespace Bridge.React.Tests
 				);
 			});
 
-            Test("DOM.Div with ClassName and empty aria value", assert =>
+            Test("DOM.Div with ClassName and empty data value", assert =>
             {
                 var done = assert.Async();
                 TestComponentMounter.Render(
-                    DOM.Div(new Attributes { ClassName = "test", Aria = new { } }, "Hello"),
+                    DOM.Div(new Attributes { ClassName = "test", Data = new { } }, "Hello"),
                     container => {
                         assert.Ok(true); // Only making sure that a null attributes references doesn't break thing (so no need to check markup)
                         done();
@@ -62,35 +62,35 @@ namespace Bridge.React.Tests
                 );
             });
 
-			Test("DOM.Div with ClassName and data 'toggle' value", assert =>
+			Test("DOM.Div with ClassName and aria 'toggle' value", assert =>
 			{
 				var done = assert.Async();
 				TestComponentMounter.Render(
-					DOM.Div(new Attributes { ClassName = "test", Data = new { toggle = "on" } }, "Hello"),
+					DOM.Div(new Attributes { ClassName = "test", Aria = new { toggle = "on" } }, "Hello"),
 					container =>
 					{
 						container.Remove();
 						var div = container.QuerySelector("div.test") as HTMLElement;
 						if (div == null)
 							throw new Exception("Unable to locate 'test' div");
-						assert.StrictEqual(div.GetAttribute("data-toggle"), "on");
+						assert.StrictEqual(div.GetAttribute("aria-toggle"), "on");
 						done();
 					}
 				);
 			});
 
-			Test("DOM.Div with ClassName and data 'toggle_me_on' value (to demonstrate underscore-to-hyphen string name replacement)", assert =>
+			Test("DOM.Div with ClassName and aria 'toggle_me_on' value (to demonstrate underscore-to-hyphen string name replacement)", assert =>
 			{
 				var done = assert.Async();
 				TestComponentMounter.Render(
-					DOM.Div(new Attributes { ClassName = "test", Data = new { toggle_me_on = "on" } }, "Hello"),
+					DOM.Div(new Attributes { ClassName = "test", Aria = new { toggle_me_on = "on" } }, "Hello"),
 					container =>
 					{
 						container.Remove();
 						var div = container.QuerySelector("div.test") as HTMLElement;
 						if (div == null)
 							throw new Exception("Unable to locate 'test' div");
-						assert.StrictEqual(div.GetAttribute("data-toggle-me-on"), "on");
+						assert.StrictEqual(div.GetAttribute("aria-toggle-me-on"), "on");
 						done();
 					}
 				);

--- a/Bridge.React.Tests/Bridge.React.Tests.csproj
+++ b/Bridge.React.Tests/Bridge.React.Tests.csproj
@@ -56,6 +56,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppDispatcherTests.cs" />
+    <Compile Include="AriaAttributeTests.cs" />
     <Compile Include="PropInstanceComparisonTests.cs" />
     <Compile Include="DataAttributeTests.cs" />
     <Compile Include="PureComponentTests.cs" />

--- a/Bridge.React.Tests/Tests.cs
+++ b/Bridge.React.Tests/Tests.cs
@@ -12,6 +12,7 @@ namespace Bridge.React.Tests
 			PureComponentTests.RunTests();
 			PropInstanceComparisonTests.Instance.RunTests();
 			DataAttributeTests.RunTests();
+            AriaAttributeTests.RunTests();
 			AppDispatcherTests.RunTests();
 		}
 	}

--- a/Bridge.React/Attributes/AnchorAttributes.cs
+++ b/Bridge.React/Attributes/AnchorAttributes.cs
@@ -6,27 +6,27 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class AnchorAttributes : ReactDomElementAttributes<HTMLAnchorElement>
 	{
-		public string Charset { private get; set; }
-		public string Coords { private get; set; }
-		public string Download { private get; set; }
-		public string Hash { private get; set; }
-		public string Host { private get; set; }
-		public string Hostname { private get; set; }
-		public string Href { private get; set; }
-		public string Hreflang { private get; set; }
-		public string Media { private get; set; }
-		public string Name { private get; set; }
-		public string Password { private get; set; }
-		public string Pathname { private get; set; }
-		public string Port { private get; set; }
-		public string Protocol { private get; set; }
-		public string Rel { private get; set; }
-		public string Rev { private get; set; }
-		public string Search { private get; set; }
-		public string Shape { private get; set; }
-		public string Target { private get; set; }
-		public string Text { private get; set; }
-		public string Type { private get; set; }
-		public string Username { private get; set; }
+		public string Charset { get; set; }
+		public string Coords { get; set; }
+		public string Download { get; set; }
+		public string Hash { get; set; }
+		public string Host { get; set; }
+		public string Hostname { get; set; }
+		public string Href { get; set; }
+		public string Hreflang { get; set; }
+		public string Media { get; set; }
+		public string Name { get; set; }
+		public string Password { get; set; }
+		public string Pathname { get; set; }
+		public string Port { get; set; }
+		public string Protocol { get; set; }
+		public string Rel { get; set; }
+		public string Rev { get; set; }
+		public string Search { get; set; }
+		public string Shape { get; set; }
+		public string Target { get; set; }
+		public string Text { get; set; }
+		public string Type { get; set; }
+		public string Username { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/AreaAttributes.cs
+++ b/Bridge.React/Attributes/AreaAttributes.cs
@@ -6,26 +6,26 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class AreaAttributes : ReactDomElementAttributes<HTMLAreaElement>
 	{
-		public string Alt { private get; set; }
-		public string Coords { private get; set; }
-		public string Download { private get; set; }
-		public string Hash { private get; set; }
-		public string Host { private get; set; }
-		public string Hostname { private get; set; }
-		public string Href { private get; set; }
-		public string Hreflang { private get; set; }
-		public string Media { private get; set; }
-		public bool NoHref { private get; set; }
-		public string Password { private get; set; }
-		public string Origin { private get; set; }
-		public string Pathname { private get; set; }
-		public string Port { private get; set; }
-		public string Protocol { private get; set; }
-		public string Rel { private get; set; }
-		public string Search { private get; set; }
-		public string Shape { private get; set; }
-		public string Target { private get; set; }
-		public string Type { private get; set; }
-		public string Username { private get; set; }
+		public string Alt { get; set; }
+		public string Coords { get; set; }
+		public string Download { get; set; }
+		public string Hash { get; set; }
+		public string Host { get; set; }
+		public string Hostname { get; set; }
+		public string Href { get; set; }
+		public string Hreflang { get; set; }
+		public string Media { get; set; }
+		public bool NoHref { get; set; }
+		public string Password { get; set; }
+		public string Origin { get; set; }
+		public string Pathname { get; set; }
+		public string Port { get; set; }
+		public string Protocol { get; set; }
+		public string Rel { get; set; }
+		public string Search { get; set; }
+		public string Shape { get; set; }
+		public string Target { get; set; }
+		public string Type { get; set; }
+		public string Username { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/BaseAttributes.cs
+++ b/Bridge.React/Attributes/BaseAttributes.cs
@@ -6,7 +6,7 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class BaseAttributes : ReactDomElementAttributes<HTMLBaseElement>
 	{
-		public string Href { private get; set; }
-		public string Target { private get; set; }
+		public string Href { get; set; }
+		public string Target { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/BodyAttributes.cs
+++ b/Bridge.React/Attributes/BodyAttributes.cs
@@ -6,11 +6,11 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class BodyAttributes : ReactDomElementAttributes<HTMLBodyElement>
 	{
-		public string ALink { private get; set; }
-		public string Background { private get; set; }
-		public string BgColor { private get; set; }
-		public string Link { private get; set; }
-		public string Text { private get; set; }
-		public string VLink { private get; set; }
+		public string ALink { get; set; }
+		public string Background { get; set; }
+		public string BgColor { get; set; }
+		public string Link { get; set; }
+		public string Text { get; set; }
+		public string VLink { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/BrAttributes.cs
+++ b/Bridge.React/Attributes/BrAttributes.cs
@@ -6,6 +6,6 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class BrAttributes : ReactDomElementAttributes<HTMLBRElement>
 	{
-		public string Clear { private get; set; }
+		public string Clear { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/ButtonAttributes.cs
+++ b/Bridge.React/Attributes/ButtonAttributes.cs
@@ -7,14 +7,14 @@ namespace Bridge.React
 	public sealed class ButtonAttributes : ReactDomElementAttributes<HTMLButtonElement>
 	{
 		[Name("autofocus")]
-		public bool AutoFocus { private get; set; }
-		public bool Disabled { private get; set; }
-		public string FormAction { private get; set; }
-		public string FormEncType { private get; set; }
-		public string FormMethod { private get; set; }
-		public bool FormNoValidate { private get; set; }
-		public string FormTarget { private get; set; }
-		public string Name { private get; set; }
-		public ButtonType Type { private get; set; }
+		public bool AutoFocus { get; set; }
+		public bool Disabled { get; set; }
+		public string FormAction { get; set; }
+		public string FormEncType { get; set; }
+		public string FormMethod { get; set; }
+		public bool FormNoValidate { get; set; }
+		public string FormTarget { get; set; }
+		public string Name { get; set; }
+		public ButtonType Type { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/CanvasAttributes.cs
+++ b/Bridge.React/Attributes/CanvasAttributes.cs
@@ -6,7 +6,7 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class CanvasAttributes : ReactDomElementAttributes<HTMLCanvasElement>
 	{
-		public int Height { private get; set; }
-		public int Width { private get; set; }
+		public int Height { get; set; }
+		public int Width { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/DListAttributes.cs
+++ b/Bridge.React/Attributes/DListAttributes.cs
@@ -6,6 +6,6 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class DListAttributes : ReactDomElementAttributes<HTMLDListElement>
 	{
-		public bool Compact { private get; set; }
+		public bool Compact { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/DelAttributes.cs
+++ b/Bridge.React/Attributes/DelAttributes.cs
@@ -6,7 +6,7 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class DelAttributes : ReactDomElementAttributes<HTMLModElement>
 	{
-		public string Cite { private get; set; }
-		public string DateTime { private get; set; }
+		public string Cite { get; set; }
+		public string DateTime { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/DomElementWithEventsAttributes.cs
+++ b/Bridge.React/Attributes/DomElementWithEventsAttributes.cs
@@ -8,78 +8,78 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public abstract class DomElementWithEventsAttributes<TCurrentTarget> : DomElementsAttributes where TCurrentTarget : HTMLElement
 	{
-		public Action<WheelEvent<TCurrentTarget>> OnCopy { private get; set; }
-		public Action<WheelEvent<TCurrentTarget>> OnCut { private get; set; }
-		public Action<WheelEvent<TCurrentTarget>> OnPaste { private get; set; }
+		public Action<WheelEvent<TCurrentTarget>> OnCopy { get; set; }
+		public Action<WheelEvent<TCurrentTarget>> OnCut { get; set; }
+		public Action<WheelEvent<TCurrentTarget>> OnPaste { get; set; }
 
-		public Action<CompositionEvent<TCurrentTarget>> OnCompositionEnd { private get; set; }
-		public Action<CompositionEvent<TCurrentTarget>> OnCompositionStart { private get; set; }
-		public Action<CompositionEvent<TCurrentTarget>> OnCompositionUpdate { private get; set; }
+		public Action<CompositionEvent<TCurrentTarget>> OnCompositionEnd { get; set; }
+		public Action<CompositionEvent<TCurrentTarget>> OnCompositionStart { get; set; }
+		public Action<CompositionEvent<TCurrentTarget>> OnCompositionUpdate { get; set; }
 
-		public Action<KeyboardEvent<TCurrentTarget>> OnKeyDown { private get; set; }
-		public Action<KeyboardEvent<TCurrentTarget>> OnKeyPress { private get; set; }
-		public Action<KeyboardEvent<TCurrentTarget>> OnKeyUp { private get; set; }
+		public Action<KeyboardEvent<TCurrentTarget>> OnKeyDown { get; set; }
+		public Action<KeyboardEvent<TCurrentTarget>> OnKeyPress { get; set; }
+		public Action<KeyboardEvent<TCurrentTarget>> OnKeyUp { get; set; }
 
-		public Action<FocusEvent<TCurrentTarget>> OnFocus { private get; set; }
-		public Action<FocusEvent<TCurrentTarget>> OnBlur { private get; set; }
+		public Action<FocusEvent<TCurrentTarget>> OnFocus { get; set; }
+		public Action<FocusEvent<TCurrentTarget>> OnBlur { get; set; }
 
-		public Action<FormEvent<TCurrentTarget>> OnChange { private get; set; }
-		public Action<FormEvent<TCurrentTarget>> OnInput { private get; set; }
-		public Action<FormEvent<TCurrentTarget>> OnSubmit { private get; set; }
+		public Action<FormEvent<TCurrentTarget>> OnChange { get; set; }
+		public Action<FormEvent<TCurrentTarget>> OnInput { get; set; }
+		public Action<FormEvent<TCurrentTarget>> OnSubmit { get; set; }
 
-		public Action<MouseEvent<TCurrentTarget>> OnClick { private get; set; }
-		public Action<MouseEvent<TCurrentTarget>> OnContextMenu { private get; set; }
-		public Action<MouseEvent<TCurrentTarget>> OnDoubleClick { private get; set; }
-		public Action<DragEvent<TCurrentTarget>> OnDrag { private get; set; }
-		public Action<DragEvent<TCurrentTarget>> OnDragEnd { private get; set; }
-		public Action<DragEvent<TCurrentTarget>> OnDragEnter { private get; set; }
-		public Action<DragEvent<TCurrentTarget>> OnDragExit { private get; set; }
-		public Action<DragEvent<TCurrentTarget>> OnDragLeave { private get; set; }
-		public Action<DragEvent<TCurrentTarget>> OnDragOver { private get; set; }
-		public Action<DragEvent<TCurrentTarget>> OnDragStart { private get; set; }
-		public Action<DragEvent<TCurrentTarget>> OnDrop { private get; set; }
-		public Action<MouseEvent<TCurrentTarget>> OnMouseDown { private get; set; }
-		public Action<MouseEvent<TCurrentTarget>> OnMouseEnter { private get; set; }
-		public Action<MouseEvent<TCurrentTarget>> OnMouseLeave { private get; set; }
-		public Action<MouseEvent<TCurrentTarget>> OnMouseMove { private get; set; }
-		public Action<MouseEvent<TCurrentTarget>> OnMouseOut { private get; set; }
-		public Action<MouseEvent<TCurrentTarget>> OnMouseOver { private get; set; }
-		public Action<MouseEvent<TCurrentTarget>> OnMouseUp { private get; set; }
+		public Action<MouseEvent<TCurrentTarget>> OnClick { get; set; }
+		public Action<MouseEvent<TCurrentTarget>> OnContextMenu { get; set; }
+		public Action<MouseEvent<TCurrentTarget>> OnDoubleClick { get; set; }
+		public Action<DragEvent<TCurrentTarget>> OnDrag { get; set; }
+		public Action<DragEvent<TCurrentTarget>> OnDragEnd { get; set; }
+		public Action<DragEvent<TCurrentTarget>> OnDragEnter { get; set; }
+		public Action<DragEvent<TCurrentTarget>> OnDragExit { get; set; }
+		public Action<DragEvent<TCurrentTarget>> OnDragLeave { get; set; }
+		public Action<DragEvent<TCurrentTarget>> OnDragOver { get; set; }
+		public Action<DragEvent<TCurrentTarget>> OnDragStart { get; set; }
+		public Action<DragEvent<TCurrentTarget>> OnDrop { get; set; }
+		public Action<MouseEvent<TCurrentTarget>> OnMouseDown { get; set; }
+		public Action<MouseEvent<TCurrentTarget>> OnMouseEnter { get; set; }
+		public Action<MouseEvent<TCurrentTarget>> OnMouseLeave { get; set; }
+		public Action<MouseEvent<TCurrentTarget>> OnMouseMove { get; set; }
+		public Action<MouseEvent<TCurrentTarget>> OnMouseOut { get; set; }
+		public Action<MouseEvent<TCurrentTarget>> OnMouseOver { get; set; }
+		public Action<MouseEvent<TCurrentTarget>> OnMouseUp { get; set; }
 
-		public Action<SelectionEvent<TCurrentTarget>> OnSelect { private get; set; }
+		public Action<SelectionEvent<TCurrentTarget>> OnSelect { get; set; }
 
-		public Action<TouchEvent<TCurrentTarget>> OnTouchCancel { private get; set; }
-		public Action<TouchEvent<TCurrentTarget>> OnTouchEnd { private get; set; }
-		public Action<TouchEvent<TCurrentTarget>> OnTouchMove { private get; set; }
-		public Action<TouchEvent<TCurrentTarget>> OnTouchStart { private get; set; }
+		public Action<TouchEvent<TCurrentTarget>> OnTouchCancel { get; set; }
+		public Action<TouchEvent<TCurrentTarget>> OnTouchEnd { get; set; }
+		public Action<TouchEvent<TCurrentTarget>> OnTouchMove { get; set; }
+		public Action<TouchEvent<TCurrentTarget>> OnTouchStart { get; set; }
 
-		public Action<UIEvent<TCurrentTarget>> OnScroll { private get; set; }
+		public Action<UIEvent<TCurrentTarget>> OnScroll { get; set; }
 
-		public Action<WheelEvent<TCurrentTarget>> OnWheel { private get; set; }
+		public Action<WheelEvent<TCurrentTarget>> OnWheel { get; set; }
 
-		public Action<MediaEvent<TCurrentTarget>> OnAbort { private get; set; }
-		public Action<MediaEvent<TCurrentTarget>> OnCanPlay { private get; set; }
-		public Action<MediaEvent<TCurrentTarget>> OnCanPlayThrough { private get; set; }
-		public Action<MediaEvent<TCurrentTarget>> OnDurationChange { private get; set; }
-		public Action<MediaEvent<TCurrentTarget>> OnEmptied { private get; set; }
-		public Action<MediaEvent<TCurrentTarget>> OnEncrypted { private get; set; }
-		public Action<MediaEvent<TCurrentTarget>> OnEnded { private get; set; }
-		public Action<MediaEvent<TCurrentTarget>> OnError { private get; set; } // This is listed as both a media event AND an image event, but they're basically the same so just left it as a media event
-		public Action<ImageEvent<TCurrentTarget>> OnLoad { private get; set; } // This is listed as a image event but since OnError was made a media event, it's easiest to do the same for this too
-		public Action<MediaEvent<TCurrentTarget>> OnLoadedData { private get; set; }
-		public Action<MediaEvent<TCurrentTarget>> OnLoadedMetadata { private get; set; }
-		public Action<MediaEvent<TCurrentTarget>> OnLoadStart { private get; set; }
-		public Action<MediaEvent<TCurrentTarget>> OnPause { private get; set; }
-		public Action<MediaEvent<TCurrentTarget>> OnPlay { private get; set; }
-		public Action<MediaEvent<TCurrentTarget>> OnPlaying { private get; set; }
-		public Action<MediaEvent<TCurrentTarget>> OnProgress { private get; set; }
-		public Action<MediaEvent<TCurrentTarget>> OnRateChange { private get; set; }
-		public Action<MediaEvent<TCurrentTarget>> OnSeeked { private get; set; }
-		public Action<MediaEvent<TCurrentTarget>> OnSeeking { private get; set; }
-		public Action<MediaEvent<TCurrentTarget>> OnStalled { private get; set; }
-		public Action<MediaEvent<TCurrentTarget>> OnSuspend { private get; set; }
-		public Action<MediaEvent<TCurrentTarget>> OnTimeUpdate { private get; set; }
-		public Action<MediaEvent<TCurrentTarget>> OnVolumeChange { private get; set; }
-		public Action<MediaEvent<TCurrentTarget>> OnWaiting { private get; set; }
+		public Action<MediaEvent<TCurrentTarget>> OnAbort { get; set; }
+		public Action<MediaEvent<TCurrentTarget>> OnCanPlay { get; set; }
+		public Action<MediaEvent<TCurrentTarget>> OnCanPlayThrough { get; set; }
+		public Action<MediaEvent<TCurrentTarget>> OnDurationChange { get; set; }
+		public Action<MediaEvent<TCurrentTarget>> OnEmptied { get; set; }
+		public Action<MediaEvent<TCurrentTarget>> OnEncrypted { get; set; }
+		public Action<MediaEvent<TCurrentTarget>> OnEnded { get; set; }
+		public Action<MediaEvent<TCurrentTarget>> OnError { get; set; } // This is listed as both a media event AND an image event, but they're basically the same so just left it as a media event
+		public Action<ImageEvent<TCurrentTarget>> OnLoad { get; set; } // This is listed as a image event but since OnError was made a media event, it's easiest to do the same for this too
+		public Action<MediaEvent<TCurrentTarget>> OnLoadedData { get; set; }
+		public Action<MediaEvent<TCurrentTarget>> OnLoadedMetadata { get; set; }
+		public Action<MediaEvent<TCurrentTarget>> OnLoadStart { get; set; }
+		public Action<MediaEvent<TCurrentTarget>> OnPause { get; set; }
+		public Action<MediaEvent<TCurrentTarget>> OnPlay { get; set; }
+		public Action<MediaEvent<TCurrentTarget>> OnPlaying { get; set; }
+		public Action<MediaEvent<TCurrentTarget>> OnProgress { get; set; }
+		public Action<MediaEvent<TCurrentTarget>> OnRateChange { get; set; }
+		public Action<MediaEvent<TCurrentTarget>> OnSeeked { get; set; }
+		public Action<MediaEvent<TCurrentTarget>> OnSeeking { get; set; }
+		public Action<MediaEvent<TCurrentTarget>> OnStalled { get; set; }
+		public Action<MediaEvent<TCurrentTarget>> OnSuspend { get; set; }
+		public Action<MediaEvent<TCurrentTarget>> OnTimeUpdate { get; set; }
+		public Action<MediaEvent<TCurrentTarget>> OnVolumeChange { get; set; }
+		public Action<MediaEvent<TCurrentTarget>> OnWaiting { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/DomElementsAttributes.cs
+++ b/Bridge.React/Attributes/DomElementsAttributes.cs
@@ -24,6 +24,12 @@ namespace Bridge.React
 		/// </summary>
 		public dynamic Data { private get; set; }
 
+        /// <summary>
+        /// Any properties on this reference will be taken to form "aria-*" attributes (eg. if the Aria reference has a "hidden" property set to "true" then the attributes
+        /// passed to React will include a "aria-hidden" value with the value "true"). The properties on the Aria reference should not include the "aria-" prefix.
+        /// </summary>
+        public dynamic Aria { private get; set; }
+
 		/// <summary>
 		/// Warning: If this is used then the element may have no other child specified
 		/// </summary>

--- a/Bridge.React/Attributes/DomElementsAttributes.cs
+++ b/Bridge.React/Attributes/DomElementsAttributes.cs
@@ -6,15 +6,15 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public abstract class DomElementsAttributes
 	{
-		public string ClassName { private get; set; }
-		public string Id { private get; set; }
-		public string AccessKey { private get; set; }
-		public ContentEditable ContentEditable { private get; set; }
-		public TextDirection Dir { private get; set; }
-		public bool Draggable { private get; set; }
-		public string Lang { private get; set; }
-		public int TabIndex { private get; set; }
-		public string Title { private get; set; }
+		public string ClassName { get; set; }
+		public string Id { get; set; }
+		public string AccessKey { get; set; }
+		public ContentEditable ContentEditable { get; set; }
+		public TextDirection Dir { get; set; }
+		public bool Draggable { get; set; }
+		public string Lang { get; set; }
+		public int TabIndex { get; set; }
+		public string Title { get; set; }
 
 		/// <summary>
 		/// Any properties on this reference will be taken to form "data-*" attributes (eg. if the Data reference has a "toggle" property set to "on" then the attributes
@@ -22,18 +22,18 @@ namespace Bridge.React
 		/// hyphens are not valid for use in C# property names, hyphens should be replaced by underscores and the underscores will be transformed back into hyphens
 		/// when the React attributes are set (eg. if the Data reference has a property "toggle_me" then an attribute "data-toggle-me" will be set in React).
 		/// </summary>
-		public dynamic Data { private get; set; }
+		public dynamic Data { get; set; }
 
         /// <summary>
         /// Any properties on this reference will be taken to form "aria-*" attributes (eg. if the Aria reference has a "hidden" property set to "true" then the attributes
         /// passed to React will include a "aria-hidden" value with the value "true"). The properties on the Aria reference should not include the "aria-" prefix.
         /// </summary>
-        public dynamic Aria { private get; set; }
+        public dynamic Aria { get; set; }
 
 		/// <summary>
 		/// Warning: If this is used then the element may have no other child specified
 		/// </summary>
 		[Name("dangerouslySetInnerHTML")]
-		public RawHtml DangerouslySetInnerHTML { private get; set; }
+		public RawHtml DangerouslySetInnerHTML { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/EmbedAttributes.cs
+++ b/Bridge.React/Attributes/EmbedAttributes.cs
@@ -6,10 +6,10 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class EmbedAttributes : ReactDomElementAttributes<HTMLEmbedElement>
 	{
-		public int Height { private get; set; }
-		public string Name { private get; set; }
-		public string Src { private get; set; }
-		public string Type { private get; set; }
-		public string Width { private get; set; }
+		public int Height { get; set; }
+		public string Name { get; set; }
+		public string Src { get; set; }
+		public string Type { get; set; }
+		public string Width { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/FieldSetAttributes.cs
+++ b/Bridge.React/Attributes/FieldSetAttributes.cs
@@ -6,8 +6,8 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class FieldSetAttributes : ReactDomElementAttributes<HTMLFieldSetElement>
 	{
-		public bool Disabled { private get; set; }
-		public string Name { private get; set; }
-		public bool WillValidate { private get; set; }
+		public bool Disabled { get; set; }
+		public string Name { get; set; }
+		public bool WillValidate { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/FormAttributes.cs
+++ b/Bridge.React/Attributes/FormAttributes.cs
@@ -6,15 +6,15 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class FormAttributes : ReactDomElementAttributes<HTMLFormElement>
 	{
-		public string AcceptCharset { private get; set; }
-		public string Action { private get; set; }
+		public string AcceptCharset { get; set; }
+		public string Action { get; set; }
 		[Name("autocomplete")]
-		public Union<string, AutoComplete> AutoComplete { private get; set; }
-		public string Encoding { private get; set; }
-		public string Enctype { private get; set; }
-		public string Method { private get; set; }
-		public string Name { private get; set; }
-		public bool NoValidate { private get; set; }
-		public string Target { private get; set; }
+		public Union<string, AutoComplete> AutoComplete { get; set; }
+		public string Encoding { get; set; }
+		public string Enctype { get; set; }
+		public string Method { get; set; }
+		public string Name { get; set; }
+		public bool NoValidate { get; set; }
+		public string Target { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/HRAttributes.cs
+++ b/Bridge.React/Attributes/HRAttributes.cs
@@ -6,10 +6,10 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class HRAttributes : ReactDomElementAttributes<HTMLHRElement>
 	{
-		public string Color { private get; set; }
+		public string Color { get; set; }
 		[Name("noshade")]
-		public bool NoShade { private get; set; }
-		public string Size { private get; set; }
-		public string Width { private get; set; }
+		public bool NoShade { get; set; }
+		public string Size { get; set; }
+		public string Width { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/IFrameAttributes.cs
+++ b/Bridge.React/Attributes/IFrameAttributes.cs
@@ -7,19 +7,19 @@ namespace Bridge.React
 	public sealed class IFrameAttributes : ReactDomElementAttributes<HTMLIFrameElement>
 	{
 		[Name("allowfullscreen")]
-		public bool AllowFullScreen { private get; set; }
+		public bool AllowFullScreen { get; set; }
 		[Name("frameborder")]
-		public string FrameBorder { private get; set; }
-		public int Height { private get; set; }
-		public string LongDesc { private get; set; }
-		public int MarginHeight { private get; set; }
-		public int MarginWidth { private get; set; }
-		public string Name { private get; set; }
-		public SandboxOptions Sandbox { private get; set; }
-		public string Scrolling { private get; set; }
-		public bool Seamless { private get; set; }
-		public string Src { private get; set; }
-		public string SrcDoc { private get; set; }
-		public int Width { private get; set; }
+		public string FrameBorder { get; set; }
+		public int Height { get; set; }
+		public string LongDesc { get; set; }
+		public int MarginHeight { get; set; }
+		public int MarginWidth { get; set; }
+		public string Name { get; set; }
+		public SandboxOptions Sandbox { get; set; }
+		public string Scrolling { get; set; }
+		public bool Seamless { get; set; }
+		public string Src { get; set; }
+		public string SrcDoc { get; set; }
+		public int Width { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/ImageAttributes.cs
+++ b/Bridge.React/Attributes/ImageAttributes.cs
@@ -6,13 +6,13 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class ImageAttributes : ReactDomElementAttributes<HTMLImageElement>
 	{
-		public string Alt { private get; set; }
-		public string CrossOrigin { private get; set; }
-		public int Height { private get; set; }
-		public bool IsMap { private get; set; }
-		public string Src { private get; set; }
-		public string SrcSet { private get; set; }
-		public string UseMap { private get; set; }
-		public int Width { private get; set; }
+		public string Alt { get; set; }
+		public string CrossOrigin { get; set; }
+		public int Height { get; set; }
+		public bool IsMap { get; set; }
+		public string Src { get; set; }
+		public string SrcSet { get; set; }
+		public string UseMap { get; set; }
+		public int Width { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/InputAttributes.cs
+++ b/Bridge.React/Attributes/InputAttributes.cs
@@ -6,40 +6,40 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class InputAttributes : ReactDomElementAttributes<HTMLInputElement>
 	{
-		public string Accept { private get; set; }
-		public string Alt { private get; set; }
-		public Union<string, AutoComplete> AutoComplete { private get; set; }
-		public bool AutoFocus { private get; set; }
-		public bool AutoSave { private get; set; }
-		public bool Checked { private get; set; }
-		public bool DefaultChecked { private get; set; }
-		public string DefaultValue { private get; set; }
-		public bool Disabled { private get; set; }
-		public string FormAction { private get; set; }
-		public string FormEncType { private get; set; }
-		public string FormMethod { private get; set; }
-		public bool FormNoValidate { private get; set; }
-		public string FormTarget { private get; set; }
-		public int Height { private get; set; }
+		public string Accept { get; set; }
+		public string Alt { get; set; }
+		public Union<string, AutoComplete> AutoComplete { get; set; }
+		public bool AutoFocus { get; set; }
+		public bool AutoSave { get; set; }
+		public bool Checked { get; set; }
+		public bool DefaultChecked { get; set; }
+		public string DefaultValue { get; set; }
+		public bool Disabled { get; set; }
+		public string FormAction { get; set; }
+		public string FormEncType { get; set; }
+		public string FormMethod { get; set; }
+		public bool FormNoValidate { get; set; }
+		public string FormTarget { get; set; }
+		public int Height { get; set; }
 		// Note: "Indeterminate" is not support by React (see https://github.com/facebook/react/issues/1798)
-		public string Max { private get; set; }
-		public int MaxLength { private get; set; }
-		public string Min { private get; set; }
-		public bool Multiple { private get; set; }
-		public string Name { private get; set; }
-		public string Pattern { private get; set; }
-		public string Placeholder { private get; set; }
-		public bool ReadOnly { private get; set; }
-		public bool Required { private get; set; }
-		public string SelectionDirection { private get; set; }
-		public int SelectionEnd { private get; set; }
-		public int SelectionStart { private get; set; }
-		public int Size { private get; set; }
-		public string Src { private get; set; }
-		public string Step { private get; set; }
-		public InputType Type { private get; set; }
-		public string UseMap { private get; set; }
-		public string Value { private get; set; }
-		public int Width { private get; set; }
+		public string Max { get; set; }
+		public int MaxLength { get; set; }
+		public string Min { get; set; }
+		public bool Multiple { get; set; }
+		public string Name { get; set; }
+		public string Pattern { get; set; }
+		public string Placeholder { get; set; }
+		public bool ReadOnly { get; set; }
+		public bool Required { get; set; }
+		public string SelectionDirection { get; set; }
+		public int SelectionEnd { get; set; }
+		public int SelectionStart { get; set; }
+		public int Size { get; set; }
+		public string Src { get; set; }
+		public string Step { get; set; }
+		public InputType Type { get; set; }
+		public string UseMap { get; set; }
+		public string Value { get; set; }
+		public int Width { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/InsAttributes.cs
+++ b/Bridge.React/Attributes/InsAttributes.cs
@@ -6,7 +6,7 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class InsAttributes : ReactDomElementAttributes<HTMLModElement>
 	{
-		public string Cite { private get; set; }
-		public string DateTime { private get; set; }
+		public string Cite { get; set; }
+		public string DateTime { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/KeyGenAttributes.cs
+++ b/Bridge.React/Attributes/KeyGenAttributes.cs
@@ -7,11 +7,11 @@ namespace Bridge.React
 	public sealed class KeygenAttributes : ReactDomElementAttributes<HTMLKeygenElement>
 	{
 		[Name("autofocus")]
-		public bool AutoFocus { private get; set; }
+		public bool AutoFocus { get; set; }
 		[Name("autosave")]
-		public bool AutoSave { private get; set; }
-		public string Challenge { private get; set; }
-		public bool Disabled { private get; set; }
-		public string KeyType { private get; set; }
+		public bool AutoSave { get; set; }
+		public string Challenge { get; set; }
+		public bool Disabled { get; set; }
+		public string KeyType { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/LIAttributes.cs
+++ b/Bridge.React/Attributes/LIAttributes.cs
@@ -6,7 +6,7 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class LIAttributes : ReactDomElementAttributes<HTMLLIElement>
 	{
-		public string Type { private get; set; }
-		public int Value { private get; set; }
+		public string Type { get; set; }
+		public int Value { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/LabelAttributes.cs
+++ b/Bridge.React/Attributes/LabelAttributes.cs
@@ -6,6 +6,6 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class LabelAttributes : ReactDomElementAttributes<HTMLLabelElement>
 	{
-		public string HtmlFor { private get; set; }
+		public string HtmlFor { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/LinkAttributes.cs
+++ b/Bridge.React/Attributes/LinkAttributes.cs
@@ -6,12 +6,12 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class LinkAttributes : ReactDomElementAttributes<HTMLLinkElement>
 	{
-		public bool Disabled { private get; set; }
-		public string Href { private get; set; }
+		public bool Disabled { get; set; }
+		public string Href { get; set; }
 		[Name("hreflang")]
-		public string HrefLang { private get; set; }
-		public string Media { private get; set; }
-		public string Rel { private get; set; }
-		public string Type { private get; set; }
+		public string HrefLang { get; set; }
+		public string Media { get; set; }
+		public string Rel { get; set; }
+		public string Type { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/MapAttributes.cs
+++ b/Bridge.React/Attributes/MapAttributes.cs
@@ -6,6 +6,6 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class MapAttributes : ReactDomElementAttributes<HTMLMapElement>
 	{
-		public string Name { private get; set; }
+		public string Name { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/MetaAttributes.cs
+++ b/Bridge.React/Attributes/MetaAttributes.cs
@@ -6,8 +6,8 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class MetaAttributes : ReactDomElementAttributes<HTMLMetaElement>
 	{
-		public string Content { private get; set; }
-		public string HttpEquiv { private get; set; }
-		public string Name { private get; set; }
+		public string Content { get; set; }
+		public string HttpEquiv { get; set; }
+		public string Name { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/MeterAttributes.cs
+++ b/Bridge.React/Attributes/MeterAttributes.cs
@@ -6,10 +6,10 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class MeterAttributes : ReactDomElementAttributes<HTMLMeterElement>
 	{
-		public double High { private get; set; }
-		public double Low { private get; set; }
-		public double Max { private get; set; }
-		public double Min { private get; set; }
-		public double Optimum { private get; set; }
+		public double High { get; set; }
+		public double Low { get; set; }
+		public double Max { get; set; }
+		public double Min { get; set; }
+		public double Optimum { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/OListAttributes.cs
+++ b/Bridge.React/Attributes/OListAttributes.cs
@@ -6,8 +6,8 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class OListAttributes : ReactDomElementAttributes<HTMLOListElement>
 	{
-		public bool Reversed { private get; set; }
-		public int Start { private get; set; }
-		public OListType Type { private get; set; }
+		public bool Reversed { get; set; }
+		public int Start { get; set; }
+		public OListType Type { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/ObjectAttributes.cs
+++ b/Bridge.React/Attributes/ObjectAttributes.cs
@@ -6,13 +6,13 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class ObjectAttributes : ReactDomElementAttributes<HTMLObjectElement>
 	{
-		public new string Data { private get; set; }
-		public int Height { private get; set; }
-		public string Name { private get; set; }
-		public string Type { private get; set; }
-		public bool TypeMustMatch { private get; set; }
-		public string useMap { private get; set; }
-		public int Width { private get; set; }
-		public bool WillValidate { private get; set; }
+		public new string Data { get; set; }
+		public int Height { get; set; }
+		public string Name { get; set; }
+		public string Type { get; set; }
+		public bool TypeMustMatch { get; set; }
+		public string useMap { get; set; }
+		public int Width { get; set; }
+		public bool WillValidate { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/OptGroupAttributes.cs
+++ b/Bridge.React/Attributes/OptGroupAttributes.cs
@@ -6,7 +6,7 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class OptGroupAttributes : ReactDomElementAttributes<HTMLOptGroupElement>
 	{
-		public bool Disabled { private get; set; }
-		public string Label { private get; set; }
+		public bool Disabled { get; set; }
+		public string Label { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/OptionAttributes.cs
+++ b/Bridge.React/Attributes/OptionAttributes.cs
@@ -6,8 +6,8 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class OptionAttributes : ReactDomElementAttributes<HTMLOptionElement>
 	{
-		public bool Disabled { private get; set; }
-		public string Label { private get; set; }
-		public string Value { private get; set; }
+		public bool Disabled { get; set; }
+		public string Label { get; set; }
+		public string Value { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/OutputAttributes.cs
+++ b/Bridge.React/Attributes/OutputAttributes.cs
@@ -6,8 +6,8 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class OutputAttributes : ReactDomElementAttributes<HTMLOutputElement>
 	{
-		public string DefaultValue { private get; set; }
-		public string Name { private get; set; }
-		public string Type { private get; set; }
+		public string DefaultValue { get; set; }
+		public string Name { get; set; }
+		public string Type { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/ParamAttributes.cs
+++ b/Bridge.React/Attributes/ParamAttributes.cs
@@ -6,6 +6,6 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class ParamAttributes : ReactDomElementAttributes<HTMLParamElement>
 	{
-		public string Name { private get; set; }
+		public string Name { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/ProgressAttributes.cs
+++ b/Bridge.React/Attributes/ProgressAttributes.cs
@@ -6,7 +6,7 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class ProgressAttributes : ReactDomElementAttributes<HTMLProgressElement>
 	{
-		public double Max { private get; set; }
-		public double Value { private get; set; }
+		public double Max { get; set; }
+		public double Value { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/QuoteAttributes.cs
+++ b/Bridge.React/Attributes/QuoteAttributes.cs
@@ -6,6 +6,6 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class QuoteAttributes : ReactDomElementAttributes<HTMLQuoteElement>
 	{
-		public string Cite { private get; set; }
+		public string Cite { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/RawHtml.cs
+++ b/Bridge.React/Attributes/RawHtml.cs
@@ -3,6 +3,6 @@
     public sealed class RawHtml
     {
         [Name("__html")]
-        public string Html { private get; set; }
+        public string Html { get; set; }
     }
 }

--- a/Bridge.React/Attributes/ReactDomElementAttributes.cs
+++ b/Bridge.React/Attributes/ReactDomElementAttributes.cs
@@ -13,15 +13,15 @@ namespace Bridge.React
 		/// but it is also permitted to use strings (actually, React allows any type but it to-strings its value, so it makes more sense to explicitly
 		/// limit the values to integers and strings).
 		/// </summary>
-		public Union<string, int> Key { private get; set; }
+		public Union<string, int> Key { get; set; }
 
 		/// <summary>
 		/// The Ref callback allows access to the real DOM element of the React component that is being rendered - the callback will be provided a reference
 		/// to the DOM element as the component is mounted (this is not something that is required very often, but may be useful for integrating with third
 		/// party libraries - for more information, see https://facebook.github.io/react/docs/more-about-refs.html)
 		/// </summary>
-		public Action<TCurrentTarget> Ref { private get; set; }
+		public Action<TCurrentTarget> Ref { get; set; }
 
-		public ReactStyle Style { private get; set; }
+		public ReactStyle Style { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/ScriptAttributes.cs
+++ b/Bridge.React/Attributes/ScriptAttributes.cs
@@ -6,12 +6,12 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class ScriptAttributes : ReactDomElementAttributes<HTMLScriptElement>
 	{
-		public bool Async { private get; set; }
-		public string Charset { private get; set; }
-		public string CrossOrigin { private get; set; }
-		public bool Defer { private get; set; }
-		public string Text { private get; set; }
-		public string Type { private get; set; }
-		public string Src { private get; set; }
+		public bool Async { get; set; }
+		public string Charset { get; set; }
+		public string CrossOrigin { get; set; }
+		public bool Defer { get; set; }
+		public string Text { get; set; }
+		public string Type { get; set; }
+		public string Src { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/SelectAttributes.cs
+++ b/Bridge.React/Attributes/SelectAttributes.cs
@@ -7,23 +7,23 @@ namespace Bridge.React
 	public sealed class SelectAttributes : ReactDomElementAttributes<HTMLSelectElement>
 	{
 		[Name("autofocus")]
-		public bool AutoFocus { private get; set; }
-		public bool Disabled { private get; set; }
-		public int Length { private get; set; }
-		public bool Multiple { private get; set; }
-		public string Name { private get; set; }
-		public bool Required { private get; set; }
-		public int Size { private get; set; }
-		public string Src { private get; set; }
-		public string Type { private get; set; }
+		public bool AutoFocus { get; set; }
+		public bool Disabled { get; set; }
+		public int Length { get; set; }
+		public bool Multiple { get; set; }
+		public string Name { get; set; }
+		public bool Required { get; set; }
+		public int Size { get; set; }
+		public string Src { get; set; }
+		public string Type { get; set; }
 		/// <summary>
 		/// This property should be used (instead of Values) if Multiple is false
 		/// </summary>
-		public string Value { private get; set; }
+		public string Value { get; set; }
 		/// <summary>
 		/// This property should be used (instead of Value) if Multiple is true
 		/// </summary>
 		[Name("value")]
-		public string[] Values { private get; set; }
+		public string[] Values { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/SourceAttributes.cs
+++ b/Bridge.React/Attributes/SourceAttributes.cs
@@ -6,8 +6,8 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class SourceAttributes : ReactDomElementAttributes<HTMLSourceElement>
 	{
-		public string Media { private get; set; }
-		public string Src { private get; set; }
-		public string Type { private get; set; }
+		public string Media { get; set; }
+		public string Src { get; set; }
+		public string Type { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/StyleAttributes.cs
+++ b/Bridge.React/Attributes/StyleAttributes.cs
@@ -6,9 +6,9 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class StyleAttributes : ReactDomElementAttributes<HTMLStyleElement>
 	{
-		public string Media { private get; set; }
-		public string Type { private get; set; }
-		public bool Disabled { private get; set; }
-		public StyleSheet Sheet { private get; set; }
+		public string Media { get; set; }
+		public string Type { get; set; }
+		public bool Disabled { get; set; }
+		public StyleSheet Sheet { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/TableCellAttributes.cs
+++ b/Bridge.React/Attributes/TableCellAttributes.cs
@@ -6,9 +6,9 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class TableCellAttributes : ReactDomElementAttributes<TableCellElement>
 	{
-		public int ColSpan { private get; set; }
-		public int RowSpan { private get; set; }
-		public int CellIndex { private get; set; }
-		public string valign { private get; set; }
+		public int ColSpan { get; set; }
+		public int RowSpan { get; set; }
+		public int CellIndex { get; set; }
+		public string valign { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/TableColAttributes.cs
+++ b/Bridge.React/Attributes/TableColAttributes.cs
@@ -6,6 +6,6 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class TableColAttributes : ReactDomElementAttributes<HTMLTableColElement>
 	{
-		public int Span { private get; set; }
+		public int Span { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/TextAreaAttributes.cs
+++ b/Bridge.React/Attributes/TextAreaAttributes.cs
@@ -7,23 +7,23 @@ namespace Bridge.React
 	public sealed class TextAreaAttributes : ReactDomElementAttributes<HTMLTextAreaElement>
 	{
 		[Name("autofocus")]
-		public bool AutoFocus { private get; set; }
-		public int Cols { private get; set; }
-		public string DefaultValue { private get; set; }
-		public bool Disabled { private get; set; }
-		public int MaxLength { private get; set; }
-		public string Name { private get; set; }
-		public string Placeholder { private get; set; }
-		public bool ReadOnly { private get; set; }
-		public bool Required { private get; set; }
-		public int Rows { private get; set; }
-		public string SelectionDirection { private get; set; }
-		public int SelectionEnd { private get; set; }
-		public int SelectionStart { private get; set; }
+		public bool AutoFocus { get; set; }
+		public int Cols { get; set; }
+		public string DefaultValue { get; set; }
+		public bool Disabled { get; set; }
+		public int MaxLength { get; set; }
+		public string Name { get; set; }
+		public string Placeholder { get; set; }
+		public bool ReadOnly { get; set; }
+		public bool Required { get; set; }
+		public int Rows { get; set; }
+		public string SelectionDirection { get; set; }
+		public int SelectionEnd { get; set; }
+		public int SelectionStart { get; set; }
 		/// <summary>
 		/// This should be used to set the the value of a TextArea, React includes a warning if TextArea contents are set using children (so this is not allowed with these bindings)
 		/// </summary>
-		public string Value { private get; set; }
-		public Wrap Wrap { private get; set; }
+		public string Value { get; set; }
+		public Wrap Wrap { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/TitleAttributes.cs
+++ b/Bridge.React/Attributes/TitleAttributes.cs
@@ -6,6 +6,6 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class TitleAttributes : ReactDomElementAttributes<HTMLTitleElement>
 	{
-		public string Text { private get; set; }
+		public string Text { get; set; }
 	}
 }

--- a/Bridge.React/Attributes/TrackAttributes.cs
+++ b/Bridge.React/Attributes/TrackAttributes.cs
@@ -6,11 +6,11 @@ namespace Bridge.React
 	[ObjectLiteral]
 	public sealed class TrackAttributes : ReactDomElementAttributes<HTMLTrackElement>
 	{
-		public string Kind { private get; set; }
-		public string Src { private get; set; }
+		public string Kind { get; set; }
+		public string Src { get; set; }
 		[Name("srclang")]
-		public string SrcLang { private get; set; }
-		public string Label { private get; set; }
-		public bool Default { private get; set; }
+		public string SrcLang { get; set; }
+		public string Label { get; set; }
+		public bool Default { get; set; }
 	}
 }

--- a/Bridge.React/DOMFactoryMethodHelpers.cs
+++ b/Bridge.React/DOMFactoryMethodHelpers.cs
@@ -11,16 +11,28 @@ namespace Bridge.React
 		public static DomElementsAttributes RewriteDataAttributes(DomElementsAttributes attributes)
 		{
 			/*@
-			if (!attributes || !attributes.hasOwnProperty("data"))
+			if (!attributes || !attributes.hasOwnProperty("data") || !attributes.hasOwnProperty("aria"))
 				return attributes;
-			
+
 			var data = attributes["data"];
+			var aria = attributes["aria"];
 			delete attributes["data"];
-			for (var name in data) {
-				if (!data.hasOwnProperty(name)) {
-					continue;
+			delete attributes["aria"];
+			if (data !== undefined) {
+				for (var name in data) {
+					if (!data.hasOwnProperty(name)) {
+						continue;
+					}
+					attributes["data-" + name.replace(/_/g, '-')] = data[name];
 				}
-				attributes["data-" + name.replace('_', '-')] = data[name];
+			}
+			if (aria !== undefined) {
+				for (var name in aria) {
+					if (!aria.hasOwnProperty(name)) {
+						continue;
+					}
+					attributes["aria-" + name.replace(/_/g, '-')] = aria[name];
+				}
 			}
 			*/
 			return attributes;

--- a/Bridge.React/DOMFactoryMethodHelpers.cs
+++ b/Bridge.React/DOMFactoryMethodHelpers.cs
@@ -11,7 +11,7 @@ namespace Bridge.React
 		public static DomElementsAttributes RewriteDataAttributes(DomElementsAttributes attributes)
 		{
 			/*@
-			if (!attributes || !attributes.hasOwnProperty("data") || !attributes.hasOwnProperty("aria"))
+			if (!attributes || (!attributes.hasOwnProperty("data") && !attributes.hasOwnProperty("aria")))
 				return attributes;
 
 			var data = attributes["data"];

--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ Alternatively, you may wish to expose the component more like a traditional clas
 			return Script.Write<ReactElement>("source");
 		}
 
+		public static implicit operator Union<ReactElement, string>(Photo source)
+		{
+			return Script.Write<ReactElement>("source");
+		}
+
 		[ObjectLiteral]
 		public sealed class Props
 		{

--- a/README.md
+++ b/README.md
@@ -188,6 +188,6 @@ This would allow you to write Bridge.NET code like this:
 	  	Document.GetElementById('main')
 	);
 
-Note the use oif Bridge.React.fixAttr() to process the properties before it is passed to the underlying class. Make sure you use this if you wish to be able to pass down expanded data- and aria- properties to the underlying component.
+Note the use of Bridge.React.fixAttr() to process the properties before it is passed to the underlying class. Make sure you use this if you wish to be able to pass down expanded data- and aria- properties to the underlying component.
 
 You may prefer one approach or the other - possibly depending upon whether you prefer to think in functions or classes and possibly depending upon the complexity of the component.


### PR DESCRIPTION
Referencing issue #57, if attributes have private getters it is not possible to read the value from the attributes at all. Normally these would only be passed to the React components, but if you are building extension components you may need to read those values to modify them into a cloned properties structure before passing it to the real component (such as adding in a class name).